### PR TITLE
perf(bash): optimize shell startup time (206ms → 39ms, -81%)

### DIFF
--- a/dots/.agents/skills/herdr/SKILL.md
+++ b/dots/.agents/skills/herdr/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: herdr
+description: "Control herdr from inside it. Manage workspaces and tabs, split panes, spawn agents, read output, and wait for state changes — all via CLI commands that talk to the running herdr instance over a local unix socket. Use when running inside herdr (HERDR_ENV=1)."
+---
+
+# herdr — agent skill
+
+before using this skill, check that `HERDR_ENV=1`. if it is not set to `1`, say you are not running inside a herdr-managed pane and stop. do not inspect or control the focused herdr pane from outside herdr.
+
+you are running inside herdr, a terminal-native agent multiplexer. herdr gives you workspaces, tabs, and panes — each pane is a real terminal with its own shell, agent, server, or log stream — and you can control all of it from the cli.
+
+this means you can:
+
+- see what other panes and agents are doing
+- create tabs for separate subcontexts inside one workspace
+- split panes and run commands in them
+- start servers, watch logs, and run tests in sibling panes
+- wait for specific output before continuing
+- wait for another agent to finish
+- spawn more agent instances
+
+the `herdr` binary is available in your PATH. its workspace, tab, pane, and wait commands talk to the running herdr instance over a local unix socket.
+
+if you need the raw protocol or full api reference, read the [socket api docs](https://herdr.dev/docs/socket-api/).
+
+## concepts
+
+**workspaces** are project contexts. each workspace has one or more tabs. unless manually renamed, a workspace's label follows the first tab's root pane — usually the repo name, otherwise the root pane's current folder name.
+
+**tabs** are subcontexts inside a workspace. each tab has one or more panes.
+
+**panes** are terminal splits inside a tab. each pane runs its own process — a shell, an agent, a server, anything.
+
+**agent status** is detected automatically by herdr. the api exposes one public field for it:
+
+- `agent_status` — `idle`, `working`, `blocked`, `done`, `unknown`
+
+`done` means the agent finished, but you have not looked at that finished pane yet.
+
+plain shells still exist as panes, but herdr's sidebar agent section intentionally focuses on detected agents rather than listing every shell.
+
+**ids** — workspace ids look like `1`, `2`. tab ids look like `1:1`, `1:2`, `2:1`. pane ids look like `1-1`, `1-2`, `2-1`. these are compact public ids for the current live session.
+
+important: ids can compact when tabs, panes, or workspaces are closed. do not treat them as durable ids. re-read ids from `workspace list`, `tab list`, `pane list`, or create/split responses when you need a current id. do not guess that an older `1-3` is still the same pane later.
+
+## discover yourself
+
+see what panes exist and which one is focused:
+
+```bash
+herdr pane list
+```
+
+the focused pane is yours. other panes are your neighbors.
+
+list workspaces:
+
+```bash
+herdr workspace list
+```
+
+## tab management
+
+list tabs in the current workspace:
+
+```bash
+herdr tab list --workspace 1
+```
+
+create a new tab:
+
+```bash
+herdr tab create --workspace 1
+```
+
+without `--label`, the new tab keeps the default numbered tab name.
+
+create and name it in one step:
+
+```bash
+herdr tab create --workspace 1 --label "logs"
+```
+
+rename it:
+
+```bash
+herdr tab rename 1:2 "logs"
+```
+
+focus it:
+
+```bash
+herdr tab focus 1:2
+```
+
+close it:
+
+```bash
+herdr tab close 1:2
+```
+
+## read another pane
+
+see what is on another pane's screen:
+
+```bash
+herdr pane read 1-1 --source recent --lines 50
+```
+
+- `--source visible` = current viewport
+- `--source recent` = recent scrollback as rendered in the pane
+- `--source recent-unwrapped` = recent terminal text with soft wraps joined back together
+
+## split a pane and run a command
+
+split your pane to the right and keep focus on your current pane:
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+```
+
+that prints json with the new pane nested at `result.pane.pane_id`. parse that value, then run a command in that pane:
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+```
+
+split downward instead:
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+```
+
+## wait for output
+
+block until specific text appears in a pane. useful for waiting on servers, builds, and tests.
+
+for `--source recent`, matching uses unwrapped recent terminal text, so pane width and soft wrapping do not break matches. `pane read --source recent` still shows the pane as rendered. if you want to inspect the same transcript that the waiter matches, use `pane read --source recent-unwrapped`.
+
+```bash
+herdr wait output 1-3 --match "ready on port 3000" --timeout 30000
+```
+
+with regex:
+
+```bash
+herdr wait output 1-3 --match "server.*ready" --regex --timeout 30000
+```
+
+if it times out, exit code is `1`.
+
+## wait for an agent status
+
+block until another agent reaches a specific status:
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 60000
+```
+
+use this when you want the same `done` / `idle` distinction the UI shows.
+
+## send text or keys to a pane
+
+send text without pressing Enter:
+
+```bash
+herdr pane send-text 1-1 "hello from claude"
+```
+
+press Enter or other keys:
+
+```bash
+herdr pane send-keys 1-1 Enter
+```
+
+`pane run` sends the text and then a real `Enter` key in one request:
+
+```bash
+herdr pane run 1-1 "echo hello"
+```
+
+## workspace management
+
+create a new workspace:
+
+```bash
+herdr workspace create --cwd /path/to/project
+```
+
+without `--label`, the new workspace keeps the default cwd-based name.
+
+create and name one in one step:
+
+```bash
+herdr workspace create --cwd /path/to/project --label "api server"
+```
+
+create one without focusing it:
+
+```bash
+herdr workspace create --no-focus
+```
+
+focus a workspace:
+
+```bash
+herdr workspace focus 2
+```
+
+rename:
+
+```bash
+herdr workspace rename 1 "api server"
+```
+
+close:
+
+```bash
+herdr workspace close 2
+```
+
+## close a pane
+
+```bash
+herdr pane close 1-3
+```
+
+## recipes
+
+### run a server and wait until it is ready
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+herdr wait output "$NEW_PANE" --match "ready" --timeout 30000
+herdr pane read "$NEW_PANE" --source recent --lines 20
+```
+
+### run tests in a separate pane and inspect the result
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+herdr pane run 1-3 "cargo test"
+herdr wait output 1-3 --match "test result" --timeout 60000
+herdr pane read 1-3 --source recent --lines 30
+```
+
+### check what another agent is working on
+
+```bash
+herdr pane list
+herdr pane read 1-1 --source recent --lines 80
+```
+
+### watch another pane robustly
+
+use this pattern when you need to coordinate with a sibling pane:
+
+```bash
+# inspect what is already there
+herdr pane read 1-3 --source recent --lines 40
+
+# wait only for the next output you expect
+herdr wait output 1-3 --match "ready" --timeout 30000
+
+# if you need to inspect the same transcript the waiter matched,
+# read the unwrapped recent text directly
+herdr pane read 1-3 --source recent-unwrapped --lines 40
+```
+
+### spawn a new agent and give it a task
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+herdr pane run 1-3 "claude"
+herdr wait output 1-3 --match ">" --timeout 15000
+herdr pane run 1-3 "review the test coverage in src/api/"
+```
+
+### coordinate with another agent
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 120000
+herdr pane read 1-1 --source recent --lines 100
+```
+
+## notes
+
+- `workspace list`, `workspace create`, `tab list`, `tab create`, `tab get`, `tab focus`, `tab rename`, `tab close`, `pane list`, `pane get`, `pane split`, `wait output`, and `wait agent-status` print json on success.
+- `pane read` prints text, not json.
+- `pane read --format ansi` or `pane read --ansi` returns a rendered ANSI snapshot for TUI feedback loops.
+- `pane read --source recent-unwrapped` is useful when you want to inspect the same unwrapped transcript that `wait output --source recent` matches against.
+- `pane send-text`, `pane send-keys`, and `pane run` print nothing on success.
+- parse ids from `workspace create`, `tab create`, and `pane split` responses when you need new ids. `workspace create` returns `result.workspace`, `result.tab`, and `result.root_pane`. `tab create` returns `result.tab` and `result.root_pane`. for `pane split`, the new pane id is at `result.pane.pane_id`.
+- use `pane read` for current output that already exists. use `wait output` for future output you expect next.
+- `--no-focus` on split, tab create, and workspace create keeps your current terminal context focused.
+- without `--label`, workspace create keeps cwd-based naming and tab create keeps numbered naming.
+- `--label` on tab create and workspace create applies the custom name immediately.
+- if you are running inside herdr, the `HERDR_ENV` environment variable is set to `1`.

--- a/dots/.agents/skills/herdr/SKILLmd
+++ b/dots/.agents/skills/herdr/SKILLmd
@@ -1,0 +1,300 @@
+---
+name: herdr
+description: "Control herdr from inside it. Manage workspaces and tabs, split panes, spawn agents, read output, and wait for state changes — all via CLI commands that talk to the running herdr instance over a local unix socket. Use when running inside herdr (HERDR_ENV=1)."
+---
+
+# herdr — agent skill
+
+before using this skill, check that `HERDR_ENV=1`. if it is not set to `1`, say you are not running inside a herdr-managed pane and stop. do not inspect or control the focused herdr pane from outside herdr.
+
+you are running inside herdr, a terminal-native agent multiplexer. herdr gives you workspaces, tabs, and panes — each pane is a real terminal with its own shell, agent, server, or log stream — and you can control all of it from the cli.
+
+this means you can:
+
+- see what other panes and agents are doing
+- create tabs for separate subcontexts inside one workspace
+- split panes and run commands in them
+- start servers, watch logs, and run tests in sibling panes
+- wait for specific output before continuing
+- wait for another agent to finish
+- spawn more agent instances
+
+the `herdr` binary is available in your PATH. its workspace, tab, pane, and wait commands talk to the running herdr instance over a local unix socket.
+
+if you need the raw protocol or full api reference, read the [socket api docs](https://herdr.dev/docs/socket-api/).
+
+## concepts
+
+**workspaces** are project contexts. each workspace has one or more tabs. unless manually renamed, a workspace's label follows the first tab's root pane — usually the repo name, otherwise the root pane's current folder name.
+
+**tabs** are subcontexts inside a workspace. each tab has one or more panes.
+
+**panes** are terminal splits inside a tab. each pane runs its own process — a shell, an agent, a server, anything.
+
+**agent status** is detected automatically by herdr. the api exposes one public field for it:
+
+- `agent_status` — `idle`, `working`, `blocked`, `done`, `unknown`
+
+`done` means the agent finished, but you have not looked at that finished pane yet.
+
+plain shells still exist as panes, but herdr's sidebar agent section intentionally focuses on detected agents rather than listing every shell.
+
+**ids** — workspace ids look like `1`, `2`. tab ids look like `1:1`, `1:2`, `2:1`. pane ids look like `1-1`, `1-2`, `2-1`. these are compact public ids for the current live session.
+
+important: ids can compact when tabs, panes, or workspaces are closed. do not treat them as durable ids. re-read ids from `workspace list`, `tab list`, `pane list`, or create/split responses when you need a current id. do not guess that an older `1-3` is still the same pane later.
+
+## discover yourself
+
+see what panes exist and which one is focused:
+
+```bash
+herdr pane list
+```
+
+the focused pane is yours. other panes are your neighbors.
+
+list workspaces:
+
+```bash
+herdr workspace list
+```
+
+## tab management
+
+list tabs in the current workspace:
+
+```bash
+herdr tab list --workspace 1
+```
+
+create a new tab:
+
+```bash
+herdr tab create --workspace 1
+```
+
+without `--label`, the new tab keeps the default numbered tab name.
+
+create and name it in one step:
+
+```bash
+herdr tab create --workspace 1 --label "logs"
+```
+
+rename it:
+
+```bash
+herdr tab rename 1:2 "logs"
+```
+
+focus it:
+
+```bash
+herdr tab focus 1:2
+```
+
+close it:
+
+```bash
+herdr tab close 1:2
+```
+
+## read another pane
+
+see what is on another pane's screen:
+
+```bash
+herdr pane read 1-1 --source recent --lines 50
+```
+
+- `--source visible` = current viewport
+- `--source recent` = recent scrollback as rendered in the pane
+- `--source recent-unwrapped` = recent terminal text with soft wraps joined back together
+
+## split a pane and run a command
+
+split your pane to the right and keep focus on your current pane:
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+```
+
+that prints json with the new pane nested at `result.pane.pane_id`. parse that value, then run a command in that pane:
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+```
+
+split downward instead:
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+```
+
+## wait for output
+
+block until specific text appears in a pane. useful for waiting on servers, builds, and tests.
+
+for `--source recent`, matching uses unwrapped recent terminal text, so pane width and soft wrapping do not break matches. `pane read --source recent` still shows the pane as rendered. if you want to inspect the same transcript that the waiter matches, use `pane read --source recent-unwrapped`.
+
+```bash
+herdr wait output 1-3 --match "ready on port 3000" --timeout 30000
+```
+
+with regex:
+
+```bash
+herdr wait output 1-3 --match "server.*ready" --regex --timeout 30000
+```
+
+if it times out, exit code is `1`.
+
+## wait for an agent status
+
+block until another agent reaches a specific status:
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 60000
+```
+
+use this when you want the same `done` / `idle` distinction the UI shows.
+
+## send text or keys to a pane
+
+send text without pressing Enter:
+
+```bash
+herdr pane send-text 1-1 "hello from claude"
+```
+
+press Enter or other keys:
+
+```bash
+herdr pane send-keys 1-1 Enter
+```
+
+`pane run` sends the text and then a real `Enter` key in one request:
+
+```bash
+herdr pane run 1-1 "echo hello"
+```
+
+## workspace management
+
+create a new workspace:
+
+```bash
+herdr workspace create --cwd /path/to/project
+```
+
+without `--label`, the new workspace keeps the default cwd-based name.
+
+create and name one in one step:
+
+```bash
+herdr workspace create --cwd /path/to/project --label "api server"
+```
+
+create one without focusing it:
+
+```bash
+herdr workspace create --no-focus
+```
+
+focus a workspace:
+
+```bash
+herdr workspace focus 2
+```
+
+rename:
+
+```bash
+herdr workspace rename 1 "api server"
+```
+
+close:
+
+```bash
+herdr workspace close 2
+```
+
+## close a pane
+
+```bash
+herdr pane close 1-3
+```
+
+## recipes
+
+### run a server and wait until it is ready
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+herdr wait output "$NEW_PANE" --match "ready" --timeout 30000
+herdr pane read "$NEW_PANE" --source recent --lines 20
+```
+
+### run tests in a separate pane and inspect the result
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+herdr pane run 1-3 "cargo test"
+herdr wait output 1-3 --match "test result" --timeout 60000
+herdr pane read 1-3 --source recent --lines 30
+```
+
+### check what another agent is working on
+
+```bash
+herdr pane list
+herdr pane read 1-1 --source recent --lines 80
+```
+
+### watch another pane robustly
+
+use this pattern when you need to coordinate with a sibling pane:
+
+```bash
+# inspect what is already there
+herdr pane read 1-3 --source recent --lines 40
+
+# wait only for the next output you expect
+herdr wait output 1-3 --match "ready" --timeout 30000
+
+# if you need to inspect the same transcript the waiter matched,
+# read the unwrapped recent text directly
+herdr pane read 1-3 --source recent-unwrapped --lines 40
+```
+
+### spawn a new agent and give it a task
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+herdr pane run 1-3 "claude"
+herdr wait output 1-3 --match ">" --timeout 15000
+herdr pane run 1-3 "review the test coverage in src/api/"
+```
+
+### coordinate with another agent
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 120000
+herdr pane read 1-1 --source recent --lines 100
+```
+
+## notes
+
+- `workspace list`, `workspace create`, `tab list`, `tab create`, `tab get`, `tab focus`, `tab rename`, `tab close`, `pane list`, `pane get`, `pane split`, `wait output`, and `wait agent-status` print json on success.
+- `pane read` prints text, not json.
+- `pane read --format ansi` or `pane read --ansi` returns a rendered ANSI snapshot for TUI feedback loops.
+- `pane read --source recent-unwrapped` is useful when you want to inspect the same unwrapped transcript that `wait output --source recent` matches against.
+- `pane send-text`, `pane send-keys`, and `pane run` print nothing on success.
+- parse ids from `workspace create`, `tab create`, and `pane split` responses when you need new ids. `workspace create` returns `result.workspace`, `result.tab`, and `result.root_pane`. `tab create` returns `result.tab` and `result.root_pane`. for `pane split`, the new pane id is at `result.pane.pane_id`.
+- use `pane read` for current output that already exists. use `wait output` for future output you expect next.
+- `--no-focus` on split, tab create, and workspace create keeps your current terminal context focused.
+- without `--label`, workspace create keeps cwd-based naming and tab create keeps numbered naming.
+- `--label` on tab create and workspace create applies the custom name immediately.
+- if you are running inside herdr, the `HERDR_ENV` environment variable is set to `1`.

--- a/dots/.bashrc
+++ b/dots/.bashrc
@@ -12,34 +12,53 @@ esac
 
 [ -f ~/.bash_aliases ] && . ~/.bash_aliases
 [ -f ~/.bash_colors ] && . ~/.bash_colors
-if command -v git >/dev/null 2>&1 && [ -f ~/.git-completion.bash ]; then
-    . ~/.git-completion.bash
-fi
+
+# git tab completion — source directly (rarely changes)
+[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash
 
 # ------------------------------------------------
-# pyenv
+# pyenv (lazy-loaded — defers 120ms until first `pyenv` call)
 # ------------------------------------------------
 
 export PYENV_ROOT="$HOME/.pyenv"
-command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
+export PATH="$PYENV_ROOT/bin:$PATH"
+export PATH="$PYENV_ROOT/shims:$PATH"
+
+# Lazy-load: real init runs on first use
+pyenv() {
+    unset -f pyenv
+    eval "$(command pyenv init -)"
+    pyenv "$@"
+}
 
 # ------------------------------------------------
-# Mise
+# Mise (shims mode — avoids ~25ms of complex shell code sourcing)
+# Tools are still version-aware via shims (.nvmrc / .tool-versions respected).
+# If you need per-directory switching notifications, change to:
+#   eval "$(mise activate bash)"
 # ------------------------------------------------
 
-eval "$(mise activate bash)"
+if command -v mise >/dev/null 2>&1; then
+    export PATH="$HOME/.local/share/mise/shims:$PATH"
+fi
 
 # ------------------------------------------------
-# fzf Integration
+# fzf Integration (cached)
 # ------------------------------------------------
 
-if command -v fzf >/dev/null 2>&1; then
-    eval "$(fzf --bash)"
+_fzf_bin=$(command -v fzf 2>/dev/null)
+if [[ -n "$_fzf_bin" ]]; then
+    _fzf_cache="$HOME/.cache/fzf_init.bash"
+    if [[ ! -f "$_fzf_cache" || "$_fzf_bin" -nt "$_fzf_cache" ]]; then
+        mkdir -p "$(dirname "$_fzf_cache")"
+        fzf --bash > "$_fzf_cache" 2>/dev/null || true
+    fi
+    [ -f "$_fzf_cache" ] && . "$_fzf_cache"
     export FZF_COMPLETION_TRIGGER='~~'
     if command -v rg >/dev/null 2>&1; then
         export FZF_DEFAULT_COMMAND="rg --files --no-ignore-vcs --hidden -g '!node_modules/*' -g '!.git/*' -g '!.yarn/*'"
     fi
+    unset _fzf_bin _fzf_cache
 fi
 
 # ------------------------------------------------
@@ -108,23 +127,44 @@ fi
 # Misc Interactive Config
 # ------------------------------------------------
 
-# https://github.com/ajeetdsouza/zoxide
-if command -v zoxide >/dev/null 2>&1; then
-    eval "$(zoxide init bash)"
+# https://github.com/ajeetdsouza/zoxide (cached)
+_zoxide_bin=$(command -v zoxide 2>/dev/null)
+if [[ -n "$_zoxide_bin" ]]; then
+    _zoxide_cache="$HOME/.cache/zoxide_init.bash"
+    if [[ ! -f "$_zoxide_cache" || "$_zoxide_bin" -nt "$_zoxide_cache" ]]; then
+        mkdir -p "$(dirname "$_zoxide_cache")"
+        zoxide init bash > "$_zoxide_cache" 2>/dev/null || true
+    fi
+    [ -f "$_zoxide_cache" ] && . "$_zoxide_cache"
+    unset _zoxide_bin _zoxide_cache
 fi
 
+# gh completion — cached to avoid forking gh binary every shell start
 if command -v gh >/dev/null 2>&1; then
-    eval "$(gh completion -s bash)"
+    _gh_cache="$HOME/.cache/gh_completion.bash"
+    _gh_bin=$(command -v gh)
+    if [[ ! -f "$_gh_cache" || "$_gh_bin" -nt "$_gh_cache" ]]; then
+        mkdir -p "$(dirname "$_gh_cache")"
+        gh completion -s bash > "$_gh_cache" 2>/dev/null || true
+    fi
+    [ -f "$_gh_cache" ] && . "$_gh_cache"
+    unset _gh_cache _gh_bin
 fi
 
 # Rust Cargo env
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
-# Set default editor
-export VISUAL=nvim
-export EDITOR="$VISUAL"
-
 # Load local-specific config if it exists (not committed to git)
 [ -f ~/.local.bashrc ] && . ~/.local.bashrc
 
-eval "$(starship init bash)"
+# starship — cached to avoid forking on every shell start
+_starship_cache="$HOME/.cache/starship_init.bash"
+_starship_bin=$(command -v starship 2>/dev/null)
+if [[ -n "$_starship_bin" ]]; then
+    if [[ ! -f "$_starship_cache" || "$_starship_bin" -nt "$_starship_cache" ]]; then
+        mkdir -p "$(dirname "$_starship_cache")"
+        starship init bash --print-full-init > "$_starship_cache" 2>/dev/null || true
+    fi
+    [ -f "$_starship_cache" ] && . "$_starship_cache"
+fi
+unset _starship_cache _starship_bin

--- a/dots/.config/herdr/config.toml
+++ b/dots/.config/herdr/config.toml
@@ -59,10 +59,10 @@ focus_pane_down = ["prefix+j", "ctrl+shift+j"]
 focus_pane_up = ["prefix+k", "ctrl+shift+k"]
 focus_pane_right = ["prefix+l", "ctrl+shift+l"]
 # Default Herdr pane swapping.
-swap_pane_left = "prefix+shift+h"
-swap_pane_down = "prefix+shift+j"
-swap_pane_up = "prefix+shift+k"
-swap_pane_right = "prefix+shift+l"
+swap_pane_left = "ctrl+alt+shift+h"
+swap_pane_down = "ctrl+alt+shift+j"
+swap_pane_up = "ctrl+alt+shift+k"
+swap_pane_right = "ctrl+alt+shift+l"
 
 split_vertical = ["prefix+|", "prefix+backslash"]
 split_horizontal = ["prefix+minus", "prefix+_"]
@@ -72,20 +72,20 @@ resize_mode = "prefix+="
 
 # Navigate mode: j/k select workspaces; h/l still move across panes.
 navigate_pane_left = "h"
-navigate_pane_down = "ctrl+j"
-navigate_pane_up = "ctrl+k"
+navigate_pane_down = "j"
+navigate_pane_up = "k"
 navigate_pane_right = "l"
-navigate_workspace_up = "k"
-navigate_workspace_down = "j"
+navigate_workspace_down = "ctrl+j"
+navigate_workspace_up = "ctrl+k"
 
 # Keep these unset until we decide on non-tmux equivalents.
 new_workspace = "prefix+shift+n"
 new_worktree = ""
 open_worktree = ""
 remove_worktree = ""
-previous_workspace = "prefix+("
-next_workspace = "prefix+)"
-switch_workspace = "prefix+shift+1..9"
+previous_workspace = "alt+shift+k"
+next_workspace = "alt+shift+j"
+switch_workspace = "prefix+alt+1..9"
 previous_agent = "prefix+ctrl+k"
 next_agent = "prefix+ctrl+j"
 focus_agent = "prefix+ctrl+1..9"
@@ -117,3 +117,9 @@ key = "prefix+shift+c"
 type = "plugin_action"
 command = "dots.quick-window.open"
 description = "quick window"
+
+[[keys.command]]
+key = "prefix+q"
+type = "plugin_action"
+command = "rmarganti.herdr-pluck.pluck"
+description = "pluck visible token"

--- a/dots/.config/opencode/plugins/amux-status.js
+++ b/dots/.config/opencode/plugins/amux-status.js
@@ -1,4 +1,4 @@
-// amux-status v1.4
+// amux-status v1.5
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -15,7 +15,7 @@ function getStatusDir() {
     const xdgState =
         process.env.XDG_STATE_HOME ||
         path.join(os.homedir(), '.local', 'state');
-    return path.join(xdgState, 'amux', 'opencode');
+    return path.join(xdgState, 'amux');
 }
 
 function getStatusFilePath(paneId) {
@@ -26,6 +26,7 @@ function writeStatus(paneId, status) {
     const dir = getStatusDir();
     fs.mkdirSync(dir, { recursive: true });
     const payload = JSON.stringify({
+        provider: 'opencode',
         status,
         pid: process.pid,
         ts: Math.floor(Date.now() / 1000),
@@ -35,7 +36,10 @@ function writeStatus(paneId, status) {
 
 function removeStatus(paneId) {
     const filePath = getStatusFilePath(paneId);
-    try { fs.unlinkSync(filePath); } catch (_) {}
+    try {
+        const current = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        if (current.provider === 'opencode') fs.unlinkSync(filePath);
+    } catch (_) {}
 }
 
 export default async function amuxStatusPlugin() {
@@ -66,7 +70,7 @@ export default async function amuxStatusPlugin() {
                 const sessionStatus = event.properties.status?.type;
                 const status =
                     sessionStatus === 'busy' || sessionStatus === 'retry'
-                        ? 'busy'
+                        ? 'running'
                         : 'idle';
                 writeStatus(paneId, status);
                 log('info', 'status written', {
@@ -94,8 +98,8 @@ export default async function amuxStatusPlugin() {
             }
 
             if (event.type === 'question.replied') {
-                writeStatus(paneId, 'busy');
-                log('info', 'busy status written (question replied)', {
+                writeStatus(paneId, 'running');
+                log('info', 'running status written (question replied)', {
                     paneId,
                 });
             }

--- a/dots/.config/zed/keymap.json
+++ b/dots/.config/zed/keymap.json
@@ -8,8 +8,8 @@
             "ctrl-j": "menu::SelectNext",
             "ctrl-k": "menu::SelectPrevious",
             "shift-cmd-enter": "workspace::ToggleZoom",
-            "cmd-/": "terminal_panel::Toggle",
-        },
+            "cmd-/": "terminal_panel::Toggle"
+        }
     },
 
     // ---------------------------------------------------
@@ -33,29 +33,29 @@
             // Edit CHANGELOG.md
             "space e c": [
                 "task::Spawn",
-                { "task_name": "Open Nearest CHANGELOG.md" },
+                { "task_name": "Open Nearest CHANGELOG.md" }
             ],
             // Edit .env
             "space e e": ["task::Spawn", { "task_name": "Open Nearest .env" }],
             // Edit index.ts
             "space e i": [
                 "task::Spawn",
-                { "task_name": "Open Nearest index.ts" },
+                { "task_name": "Open Nearest index.ts" }
             ],
             // Edit package.json
             "space e p": [
                 "task::Spawn",
-                { "task_name": "Open Nearest package.json" },
+                { "task_name": "Open Nearest package.json" }
             ],
             // Edit project.json
             "space e P": [
                 "task::Spawn",
-                { "task_name": "Open Nearest project.json" },
+                { "task_name": "Open Nearest project.json" }
             ],
             // Edit README.md
             "space e r": [
                 "task::Spawn",
-                { "task_name": "Open Nearest README.md" },
+                { "task_name": "Open Nearest README.md" }
             ],
 
             // File eXplorer
@@ -71,7 +71,7 @@
             // GitHub Repo
             "space g h r": [
                 "task::Spawn",
-                { "task_name": "Github Browse Repo" },
+                { "task_name": "Github Browse Repo" }
             ],
             // Git Lazy
             "space g l": ["task::Spawn", { "task_name": "Lazy Git" }],
@@ -91,7 +91,7 @@
             "space s t": "pane::DeploySearch",
             "space s T": [
                 "task::Spawn",
-                { "task_name": "TV Full Text Search" },
+                { "task_name": "TV Full Text Search" }
             ],
             // Search Wiki
             "space s w": ["task::Spawn", { "task_name": "TV Search Wiki" }],
@@ -101,12 +101,12 @@
             // Open Yesterday's diary
             "space o y": [
                 "task::Spawn",
-                { "task_name": "Open Yesterday's Diary" },
+                { "task_name": "Open Yesterday's Diary" }
             ],
 
             "space t s": "task::Spawn",
-            "space t r": "task::Rerun",
-        },
+            "space t r": "task::Rerun"
+        }
     },
 
     {
@@ -122,8 +122,8 @@
             "cmd-7": ["pane::ActivateItem", 6],
             "cmd-8": ["pane::ActivateItem", 7],
             "cmd-9": ["pane::ActivateItem", 8],
-            "cmd-0": "pane::ActivateLastItem",
-        },
+            "cmd-0": "pane::ActivateLastItem"
+        }
     },
 
     // ---------------------------------------------------
@@ -236,20 +236,20 @@
             // GitHub File Main
             "space g h f m": [
                 "task::Spawn",
-                { "task_name": "Github Browse `main` File" },
+                { "task_name": "Github Browse `main` File" }
             ],
             // GitHub File Commit
             "space g h f c": [
                 "task::Spawn",
-                { "task_name": "Github Browse Commit File" },
+                { "task_name": "Github Browse Commit File" }
             ],
             // Git checkOut file
             "space g o": "git::RestoreFile",
             // Git Next Hunk
             "space j x": "editor::GoToHunk",
             // Git Previous Hunk
-            "space k x": "editor::GoToPreviousHunk",
-        },
+            "space k x": "editor::GoToPreviousHunk"
+        }
     },
 
     // ---------------------------------------------------
@@ -262,8 +262,8 @@
             "escape": "workspace::ToggleLeftDock",
             "ctrl-h": "workspace::ActivatePaneLeft",
             "ctrl-l": "workspace::ActivatePaneRight",
-            "ctrl-j": "git_panel::FocusEditor",
-        },
+            "ctrl-j": "git_panel::FocusEditor"
+        }
     },
     {
         "context": "GitPanel && CommitEditor > Editor",
@@ -271,8 +271,8 @@
             "escape": "workspace::ToggleLeftDock",
             "ctrl-h": "workspace::ActivatePaneLeft",
             "ctrl-l": "workspace::ActivatePaneRight",
-            "ctrl-k": "git_panel::FocusChanges",
-        },
+            "ctrl-k": "git_panel::FocusChanges"
+        }
     },
 
     // ---------------------------------------------------
@@ -282,8 +282,8 @@
     {
         "context": "AgentPanel",
         "bindings": {
-            "cmd-?": "workspace::ToggleRightDock",
-        },
+            "cmd-?": "workspace::ToggleRightDock"
+        }
     },
 
     {
@@ -300,8 +300,8 @@
             "space a o": "agent::ToggleOptionsMenu",
             "space a p": "agent::ToggleProfileSelector",
             "space a r": "agent::OpenRulesLibrary",
-            "space a s": "agent::OpenSettings",
-        },
+            "space a s": "agent::OpenSettings"
+        }
     },
 
     // ---------------------------------------------------
@@ -311,8 +311,8 @@
     {
         "context": "DebugPanel",
         "bindings": {
-            "escape": "workspace::ToggleBottomDock",
-        },
+            "escape": "workspace::ToggleBottomDock"
+        }
     },
 
     // ---------------------------------------------------
@@ -322,8 +322,8 @@
     {
         "context": "ProjectPanel && not_editing",
         "bindings": {
-            "escape": "workspace::ToggleLeftDock",
-        },
+            "escape": "workspace::ToggleLeftDock"
+        }
     },
 
     // ---------------------------------------------------
@@ -339,8 +339,33 @@
             "ctrl-k": "workspace::ActivatePaneUp",
             "ctrl-j": "workspace::ActivatePaneDown",
             "ctrl-space \\": "pane::SplitRight",
-            "ctrl-space -": "pane::SplitHorizontal",
-        },
+            "ctrl-space -": "pane::SplitHorizontal"
+        }
+    },
+
+    // ---------------------------------------------------
+    // Threads sidebar
+    // ---------------------------------------------------
+
+    {
+        "context": "ThreadsSidebar > Editor",
+        "bindings": {
+            "ctrl-h": "workspace::ActivatePaneLeft",
+            "ctrl-l": "workspace::ActivatePaneRight",
+            "ctrl-k": "workspace::ActivatePaneUp",
+            "ctrl-j": "editor::MoveDown"
+        }
+    },
+    {
+        "context": "ThreadsSidebar",
+        "bindings": {
+            // [ Pane navigation ]-----------------------------
+
+            "ctrl-h": "workspace::ActivatePaneLeft",
+            "ctrl-l": "workspace::ActivatePaneRight",
+            "ctrl-k": "agents_sidebar::FocusSidebarFilter",
+            "ctrl-j": "workspace::ActivatePaneDown"
+        }
     },
 
     // ---------------------------------------------------
@@ -348,15 +373,15 @@
     // ---------------------------------------------------
 
     {
-        "context": "AgentPanel || Panel || ProjectPanel || CollabPanel || OutlinePanel || ChatPanel || VimControl || EmptyPane || SharedScreen || MarkdownPreview || KeyContextView || DebugPanel",
+        "context": "AgentPanel || ThreadsSidebar || Panel || ProjectPanel || CollabPanel || OutlinePanel || ChatPanel || VimControl || EmptyPane || SharedScreen || MarkdownPreview || KeyContextView || DebugPanel",
         "bindings": {
             // [ Pane navigation ]-----------------------------
 
             "ctrl-h": "workspace::ActivatePaneLeft",
             "ctrl-l": "workspace::ActivatePaneRight",
             "ctrl-k": "workspace::ActivatePaneUp",
-            "ctrl-j": "workspace::ActivatePaneDown",
-        },
+            "ctrl-j": "workspace::ActivatePaneDown"
+        }
     },
 
     // ---------------------------------------------------
@@ -367,7 +392,7 @@
         "context": "Editor && showing_code_actions",
         "use_key_equivalents": true,
         "bindings": {
-            "tab": "editor::ConfirmCodeAction",
-        },
-    },
+            "tab": "editor::ConfirmCodeAction"
+        }
+    }
 ]

--- a/dots/.config/zed/settings.json
+++ b/dots/.config/zed/settings.json
@@ -9,11 +9,6 @@
 {
     // [ General ]-------------------------------------
 
-    "agent_servers": {
-        "pi-acp": {
-            "type": "registry"
-        }
-    },
     "format_on_save": "on",
     "pane_split_direction_horizontal": "down",
     "pane_split_direction_vertical": "right",
@@ -75,6 +70,15 @@
     },
 
     // [ AI/Agent ]------------------------------------
+
+    "agent_servers": {
+        "opencode": {
+            "type": "registry",
+        },
+        "pi-acp": {
+            "type": "registry",
+        },
+    },
 
     "agent": {
         "dock": "left",
@@ -239,14 +243,10 @@
 
     // [ Panel Sizes ]---------------------------------
 
-    "collaboration_panel": { "dock": "right",
-                             "default_width": 480 },
-    "git_panel": { "dock": "right",
-                   "default_width": 640 },
-    "outline_panel": { "dock": "right",
-                       "default_width": 640 },
-    "project_panel": { "dock": "right",
-                       "default_width": 640 },
+    "collaboration_panel": { "dock": "right", "default_width": 480 },
+    "git_panel": { "dock": "right", "default_width": 640 },
+    "outline_panel": { "dock": "right", "default_width": 640 },
+    "project_panel": { "dock": "right", "default_width": 640 },
 
     // [ Search ]--------------------------------------
 

--- a/dots/.pi/agent/extensions/amux-status/index.ts
+++ b/dots/.pi/agent/extensions/amux-status/index.ts
@@ -1,17 +1,17 @@
-// amux-status v1.0
+// amux-status v1.1
 // Pi Coding Agent extension for amux status reporting.
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
-type Status = 'idle' | 'busy' | 'awaiting_input' | 'errored';
+type Status = "idle" | "running" | "awaiting_input" | "errored";
 
 function getStatusDir(): string {
     const xdgState =
         process.env.XDG_STATE_HOME ||
-        path.join(os.homedir(), '.local', 'state');
-    return path.join(xdgState, 'amux', 'pi');
+        path.join(os.homedir(), ".local", "state");
+    return path.join(xdgState, "amux");
 }
 
 function getStatusFilePath(paneId: string): string {
@@ -22,6 +22,7 @@ function writeStatus(paneId: string, status: Status) {
     const dir = getStatusDir();
     fs.mkdirSync(dir, { recursive: true });
     const payload = JSON.stringify({
+        provider: "pi",
         status,
         pid: process.pid,
         ts: Math.floor(Date.now() / 1000),
@@ -32,7 +33,8 @@ function writeStatus(paneId: string, status: Status) {
 function removeStatus(paneId: string) {
     const filePath = getStatusFilePath(paneId);
     try {
-        fs.unlinkSync(filePath);
+        const current = JSON.parse(fs.readFileSync(filePath, "utf8"));
+        if (current.provider === "pi") fs.unlinkSync(filePath);
     } catch (_) {}
 }
 
@@ -41,25 +43,25 @@ export default function (pi: ExtensionAPI) {
     if (!paneId) return;
 
     const cleanup = () => removeStatus(paneId);
-    process.on('exit', cleanup);
-    process.on('SIGINT', () => {
+    process.on("exit", cleanup);
+    process.on("SIGINT", () => {
         cleanup();
         process.exit(130);
     });
-    process.on('SIGTERM', () => {
+    process.on("SIGTERM", () => {
         cleanup();
         process.exit(143);
     });
 
-    pi.on('agent_start', async () => {
-        writeStatus(paneId, 'busy');
+    pi.on("agent_start", async () => {
+        writeStatus(paneId, "running");
     });
 
-    pi.on('agent_end', async () => {
-        writeStatus(paneId, 'idle');
+    pi.on("agent_end", async () => {
+        writeStatus(paneId, "idle");
     });
 
-    pi.on('session_shutdown', async () => {
+    pi.on("session_shutdown", async () => {
         cleanup();
     });
 }

--- a/dots/.pi/agent/extensions/review.ts
+++ b/dots/.pi/agent/extensions/review.ts
@@ -1,0 +1,1627 @@
+/**
+ * Code Review Extension (inspired by Codex's review feature)
+ *
+ * Provides a `/review` command that prompts the agent to review code changes.
+ * Supports multiple review modes:
+ * - Review a GitHub pull request (checks out the PR locally)
+ * - Review against a base branch (PR style)
+ * - Review uncommitted changes
+ * - Review a specific commit
+ * - Shared custom review instructions (applied to all review modes when configured)
+ *
+ * Usage:
+ * - `/review` - show interactive selector
+ * - `/review pr 123` - review PR #123 (checks out locally)
+ * - `/review pr https://github.com/owner/repo/pull/123` - review PR from URL
+ * - `/review uncommitted` - review uncommitted changes directly
+ * - `/review branch main` - review against main branch
+ * - `/review commit abc123` - review specific commit
+ * - `/review folder src docs` - review specific folders/files (snapshot, not diff)
+ * - `/review` selector includes Add/Remove custom review instructions (applies to all modes)
+ * - `/review --extra "focus on performance regressions"` - add extra review instruction (works with any mode)
+ *
+ * Project-specific review guidelines:
+ * - If a REVIEW_GUIDELINES.md file exists in the same directory as .pi,
+ *   its contents are appended to the review prompt.
+ *
+ * Note: PR review requires a clean working tree (no uncommitted changes to tracked files).
+ */
+
+import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, BorderedLoader } from "@mariozechner/pi-coding-agent";
+import {
+	Container,
+	fuzzyFilter,
+	Input,
+	type SelectItem,
+	SelectList,
+	Spacer,
+	Text,
+} from "@mariozechner/pi-tui";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+
+// State to track fresh session review (where we branched from).
+// Module-level state means only one review can be active at a time.
+// This is intentional - the UI and /end-review command assume a single active review.
+let reviewOriginId: string | undefined = undefined;
+let endReviewInProgress = false;
+let reviewCustomInstructions: string | undefined = undefined;
+
+const REVIEW_STATE_TYPE = "review-session";
+const REVIEW_ANCHOR_TYPE = "review-anchor";
+const REVIEW_SETTINGS_TYPE = "review-settings";
+const GH_SETUP_INSTRUCTIONS =
+	"Install GitHub CLI (`gh`) from https://cli.github.com/ (macOS: `brew install gh`), then sign in with `gh auth login` and verify with `gh auth status`.";
+const PR_CHECKOUT_BLOCKED_BY_PENDING_CHANGES_MESSAGE =
+	"Cannot checkout PR: you have uncommitted changes. Please commit or stash them first.";
+
+type ReviewSessionState = {
+	active: boolean;
+	originId?: string;
+};
+
+type ReviewSettingsState = {
+	customInstructions?: string;
+};
+
+function setReviewWidget(ctx: ExtensionContext, active: boolean) {
+	if (!ctx.hasUI) return;
+	if (!active) {
+		ctx.ui.setWidget("review", undefined);
+		return;
+	}
+
+	ctx.ui.setWidget("review", (_tui, theme) => {
+		const message = "Review session active, return with /end-review";
+		const text = new Text(theme.fg("warning", message), 0, 0);
+		return {
+			render(width: number) {
+				return text.render(width);
+			},
+			invalidate() {
+				text.invalidate();
+			},
+		};
+	});
+}
+
+function getReviewState(ctx: ExtensionContext): ReviewSessionState | undefined {
+	let state: ReviewSessionState | undefined;
+	for (const entry of ctx.sessionManager.getBranch()) {
+		if (entry.type === "custom" && entry.customType === REVIEW_STATE_TYPE) {
+			state = entry.data as ReviewSessionState | undefined;
+		}
+	}
+
+	return state;
+}
+
+function applyReviewState(ctx: ExtensionContext) {
+	const state = getReviewState(ctx);
+
+	if (state?.active && state.originId) {
+		reviewOriginId = state.originId;
+		setReviewWidget(ctx, true);
+		return;
+	}
+
+	reviewOriginId = undefined;
+	setReviewWidget(ctx, false);
+}
+
+function getReviewSettings(ctx: ExtensionContext): ReviewSettingsState {
+	let state: ReviewSettingsState | undefined;
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (entry.type === "custom" && entry.customType === REVIEW_SETTINGS_TYPE) {
+			state = entry.data as ReviewSettingsState | undefined;
+		}
+	}
+
+	return {
+		customInstructions: state?.customInstructions?.trim() || undefined,
+	};
+}
+
+function applyReviewSettings(ctx: ExtensionContext) {
+	const state = getReviewSettings(ctx);
+	reviewCustomInstructions = state.customInstructions?.trim() || undefined;
+}
+
+// Review target types (matching Codex's approach)
+type ReviewTarget =
+	| { type: "uncommitted" }
+	| { type: "baseBranch"; branch: string }
+	| { type: "commit"; sha: string; title?: string }
+	| { type: "pullRequest"; prNumber: number; baseBranch: string; title: string }
+	| { type: "folder"; paths: string[] };
+
+// Prompts (adapted from Codex)
+const UNCOMMITTED_PROMPT =
+	"Review the current code changes (staged, unstaged, and untracked files) and provide prioritized findings.";
+
+const BASE_BRANCH_PROMPT_WITH_MERGE_BASE =
+	"Review the code changes against the base branch '{baseBranch}'. The merge base commit for this comparison is {mergeBaseSha}. Run `git diff {mergeBaseSha}` to inspect the changes relative to {baseBranch}. Provide prioritized, actionable findings.";
+
+const BASE_BRANCH_PROMPT_FALLBACK =
+	"Review the code changes against the base branch '{branch}'. Start by finding the merge diff between the current branch and {branch}'s upstream e.g. (`git merge-base HEAD \"$(git rev-parse --abbrev-ref \"{branch}@{upstream}\")\"`), then run `git diff` against that SHA to see what changes we would merge into the {branch} branch. Provide prioritized, actionable findings.";
+
+const COMMIT_PROMPT_WITH_TITLE =
+	'Review the code changes introduced by commit {sha} ("{title}"). Provide prioritized, actionable findings.';
+
+const COMMIT_PROMPT = "Review the code changes introduced by commit {sha}. Provide prioritized, actionable findings.";
+
+const PULL_REQUEST_PROMPT =
+	'Review pull request #{prNumber} ("{title}") against the base branch \'{baseBranch}\'. The merge base commit for this comparison is {mergeBaseSha}. Run `git diff {mergeBaseSha}` to inspect the changes that would be merged. Provide prioritized, actionable findings.';
+
+const PULL_REQUEST_PROMPT_FALLBACK =
+	'Review pull request #{prNumber} ("{title}") against the base branch \'{baseBranch}\'. Start by finding the merge base between the current branch and {baseBranch} (e.g., `git merge-base HEAD {baseBranch}`), then run `git diff` against that SHA to see the changes that would be merged. Provide prioritized, actionable findings.';
+
+const FOLDER_REVIEW_PROMPT =
+	"Review the code in the following paths: {paths}. This is a snapshot review (not a diff). Read the files directly in these paths and provide prioritized, actionable findings.";
+
+// The detailed review rubric (adapted from Codex's review_prompt.md)
+const REVIEW_RUBRIC = `# Review Guidelines
+
+You are acting as a code reviewer for a proposed code change made by another engineer.
+
+Below are default guidelines for determining what to flag. These are not the final word — if you encounter more specific guidelines elsewhere (in a developer message, user message, file, or project review guidelines appended below), those override these general instructions.
+
+## Determining what to flag
+
+Flag issues that:
+1. Meaningfully impact the accuracy, performance, security, or maintainability of the code.
+2. Are discrete and actionable (not general issues or multiple combined issues).
+3. Don't demand rigor inconsistent with the rest of the codebase.
+4. Were introduced in the changes being reviewed (not pre-existing bugs).
+5. The author would likely fix if aware of them.
+6. Don't rely on unstated assumptions about the codebase or author's intent.
+7. Have provable impact on other parts of the code — it is not enough to speculate that a change may disrupt another part, you must identify the parts that are provably affected.
+8. Are clearly not intentional changes by the author.
+9. Be particularly careful with untrusted user input and follow the specific guidelines to review.
+10. Treat silent local error recovery (especially parsing/IO/network fallbacks) as high-signal review candidates unless there is explicit boundary-level justification.
+
+## Untrusted User Input
+
+1. Be careful with open redirects, they must always be checked to only go to trusted domains (?next_page=...)
+2. Always flag SQL that is not parametrized
+3. In systems with user supplied URL input, http fetches always need to be protected against access to local resources (intercept DNS resolver!)
+4. Escape, don't sanitize if you have the option (eg: HTML escaping)
+
+## Comment guidelines
+
+1. Be clear about why the issue is a problem.
+2. Communicate severity appropriately - don't exaggerate.
+3. Be brief - at most 1 paragraph.
+4. Keep code snippets under 3 lines, wrapped in inline code or code blocks.
+5. Use \`\`\`suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block). Preserve the exact leading whitespace of the replaced lines.
+6. Explicitly state scenarios/environments where the issue arises.
+7. Use a matter-of-fact tone - helpful AI assistant, not accusatory.
+8. Write for quick comprehension without close reading.
+9. Avoid excessive flattery or unhelpful phrases like "Great job...".
+
+## Review priorities
+
+1. Surface critical non-blocking human callouts (migrations, dependency churn, auth/permissions, compatibility, destructive operations) at the end.
+2. Prefer simple, direct solutions over wrappers or abstractions without clear value.
+3. Treat back pressure handling as critical to system stability.
+4. Apply system-level thinking; flag changes that increase operational risk or on-call wakeups.
+5. Ensure that errors are always checked against codes or stable identifiers, never error messages.
+
+## Fail-fast error handling (strict)
+
+When reviewing added or modified error handling, default to fail-fast behavior.
+
+1. Evaluate every new or changed \`try/catch\`: identify what can fail and why local handling is correct at that exact layer.
+2. Prefer propagation over local recovery. If the current scope cannot fully recover while preserving correctness, rethrow (optionally with context) instead of returning fallbacks.
+3. Flag catch blocks that hide failure signals (e.g. returning \`null\`/\`[]\`/\`false\`, swallowing JSON parse failures, logging-and-continue, or “best effort” silent recovery).
+4. JSON parsing/decoding should fail loudly by default. Quiet fallback parsing is only acceptable with an explicit compatibility requirement and clear tested behavior.
+5. Boundary handlers (HTTP routes, CLI entrypoints, supervisors) may translate errors, but must not pretend success or silently degrade.
+6. If a catch exists only to satisfy lint/style without real handling, treat it as a bug.
+7. When uncertain, prefer crashing fast over silent degradation.
+
+## Required human callouts (non-blocking, at the very end)
+
+After findings/verdict, you MUST append this final section:
+
+## Human Reviewer Callouts (Non-Blocking)
+
+Include only applicable callouts (no yes/no lines):
+
+- **This change adds a database migration:** <files/details>
+- **This change introduces a new dependency:** <package(s)/details>
+- **This change changes a dependency (or the lockfile):** <files/package(s)/details>
+- **This change modifies auth/permission behavior:** <what changed and where>
+- **This change introduces backwards-incompatible public schema/API/contract changes:** <what changed and where>
+- **This change includes irreversible or destructive operations:** <operation and scope>
+- **This change adds or removes feature flags:** <feature flags changed> (call out re-use of dormant feature flags!)
+- **This change changes configuration defaults:** <config var changed>
+
+Rules for this section:
+1. These are informational callouts for the human reviewer, not fix items.
+2. Do not include them in Findings unless there is an independent defect.
+3. These callouts alone must not change the verdict.
+4. Only include callouts that apply to the reviewed change.
+5. Keep each emitted callout bold exactly as written.
+6. If none apply, write "- (none)".
+
+## Priority levels
+
+Tag each finding with a priority level in the title:
+- [P0] - Drop everything to fix. Blocking release/operations. Only for universal issues that do not depend on assumptions about inputs.
+- [P1] - Urgent. Should be addressed in the next cycle.
+- [P2] - Normal. To be fixed eventually.
+- [P3] - Low. Nice to have.
+
+## Output format
+
+Provide your findings in a clear, structured format:
+1. List each finding with its priority tag, file location, and explanation.
+2. Findings must reference locations that overlap with the actual diff — don't flag pre-existing code.
+3. Keep line references as short as possible (avoid ranges over 5-10 lines; pick the most suitable subrange).
+4. Provide an overall verdict: "correct" (no blocking issues) or "needs attention" (has blocking issues).
+5. Ignore trivial style issues unless they obscure meaning or violate documented standards.
+6. Do not generate a full PR fix — only flag issues and optionally provide short suggestion blocks.
+7. End with the required "Human Reviewer Callouts (Non-Blocking)" section and all applicable bold callouts (no yes/no).
+
+Output all findings the author would fix if they knew about them. If there are no qualifying findings, explicitly state the code looks good. Don't stop at the first finding - list every qualifying issue. Then append the required non-blocking callouts section.`;
+
+async function loadProjectReviewGuidelines(cwd: string): Promise<string | null> {
+	let currentDir = path.resolve(cwd);
+
+	while (true) {
+		const piDir = path.join(currentDir, ".pi");
+		const guidelinesPath = path.join(currentDir, "REVIEW_GUIDELINES.md");
+
+		const piStats = await fs.stat(piDir).catch(() => null);
+		if (piStats?.isDirectory()) {
+			const guidelineStats = await fs.stat(guidelinesPath).catch(() => null);
+			if (guidelineStats?.isFile()) {
+				try {
+					const content = await fs.readFile(guidelinesPath, "utf8");
+					const trimmed = content.trim();
+					return trimmed ? trimmed : null;
+				} catch {
+					return null;
+				}
+			}
+			return null;
+		}
+
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) {
+			return null;
+		}
+		currentDir = parentDir;
+	}
+}
+
+/**
+ * Get the merge base between HEAD and a branch
+ */
+async function getMergeBase(
+	pi: ExtensionAPI,
+	branch: string,
+): Promise<string | null> {
+	try {
+		// First try to get the upstream tracking branch
+		const { stdout: upstream, code: upstreamCode } = await pi.exec("git", [
+			"rev-parse",
+			"--abbrev-ref",
+			`${branch}@{upstream}`,
+		]);
+
+		if (upstreamCode === 0 && upstream.trim()) {
+			const { stdout: mergeBase, code } = await pi.exec("git", ["merge-base", "HEAD", upstream.trim()]);
+			if (code === 0 && mergeBase.trim()) {
+				return mergeBase.trim();
+			}
+		}
+
+		// Fall back to using the branch directly
+		const { stdout: mergeBase, code } = await pi.exec("git", ["merge-base", "HEAD", branch]);
+		if (code === 0 && mergeBase.trim()) {
+			return mergeBase.trim();
+		}
+
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get list of local branches
+ */
+async function getLocalBranches(pi: ExtensionAPI): Promise<string[]> {
+	const { stdout, code } = await pi.exec("git", ["branch", "--format=%(refname:short)"]);
+	if (code !== 0) return [];
+	return stdout
+		.trim()
+		.split("\n")
+		.filter((b) => b.trim());
+}
+
+/**
+ * Get list of recent commits
+ */
+async function getRecentCommits(pi: ExtensionAPI, limit: number = 10): Promise<Array<{ sha: string; title: string }>> {
+	const { stdout, code } = await pi.exec("git", ["log", `--oneline`, `-n`, `${limit}`]);
+	if (code !== 0) return [];
+
+	return stdout
+		.trim()
+		.split("\n")
+		.filter((line) => line.trim())
+		.map((line) => {
+			const [sha, ...rest] = line.trim().split(" ");
+			return { sha, title: rest.join(" ") };
+		});
+}
+
+/**
+ * Check if there are uncommitted changes (staged, unstaged, or untracked)
+ */
+async function hasUncommittedChanges(pi: ExtensionAPI): Promise<boolean> {
+	const { stdout, code } = await pi.exec("git", ["status", "--porcelain"]);
+	return code === 0 && stdout.trim().length > 0;
+}
+
+/**
+ * Check if there are changes that would prevent switching branches
+ * (staged or unstaged changes to tracked files - untracked files are fine)
+ */
+async function hasPendingChanges(pi: ExtensionAPI): Promise<boolean> {
+	// Check for staged or unstaged changes to tracked files
+	const { stdout, code } = await pi.exec("git", ["status", "--porcelain"]);
+	if (code !== 0) return false;
+
+	// Filter out untracked files (lines starting with ??)
+	const lines = stdout.trim().split("\n").filter((line) => line.trim());
+	const trackedChanges = lines.filter((line) => !line.startsWith("??"));
+	return trackedChanges.length > 0;
+}
+
+/**
+ * Parse a PR reference (URL or number) and return the PR number
+ */
+function parsePrReference(ref: string): number | null {
+	const trimmed = ref.trim();
+
+	// Try as a number first
+	const num = parseInt(trimmed, 10);
+	if (!isNaN(num) && num > 0) {
+		return num;
+	}
+
+	// Try to extract from GitHub URL
+	// Formats: https://github.com/owner/repo/pull/123
+	//          github.com/owner/repo/pull/123
+	const urlMatch = trimmed.match(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
+	if (urlMatch) {
+		return parseInt(urlMatch[1], 10);
+	}
+
+	return null;
+}
+
+/**
+ * Get PR information from GitHub CLI
+ */
+async function getPrInfo(pi: ExtensionAPI, prNumber: number): Promise<{ baseBranch: string; title: string; headBranch: string } | null> {
+	const { stdout, code } = await pi.exec("gh", [
+		"pr", "view", String(prNumber),
+		"--json", "baseRefName,title,headRefName",
+	]);
+
+	if (code !== 0) return null;
+
+	try {
+		const data = JSON.parse(stdout);
+		return {
+			baseBranch: data.baseRefName,
+			title: data.title,
+			headBranch: data.headRefName,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Checkout a PR using GitHub CLI
+ */
+async function checkoutPr(pi: ExtensionAPI, prNumber: number): Promise<{ success: boolean; error?: string }> {
+	const { stdout, stderr, code } = await pi.exec("gh", ["pr", "checkout", String(prNumber)]);
+
+	if (code !== 0) {
+		return { success: false, error: stderr || stdout || "Failed to checkout PR" };
+	}
+
+	return { success: true };
+}
+
+/**
+ * Get the current branch name
+ */
+async function getCurrentBranch(pi: ExtensionAPI): Promise<string | null> {
+	const { stdout, code } = await pi.exec("git", ["branch", "--show-current"]);
+	if (code === 0 && stdout.trim()) {
+		return stdout.trim();
+	}
+	return null;
+}
+
+/**
+ * Get the default branch (main or master)
+ */
+async function getDefaultBranch(pi: ExtensionAPI): Promise<string> {
+	// Try to get from remote HEAD
+	const { stdout, code } = await pi.exec("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]);
+	if (code === 0 && stdout.trim()) {
+		return stdout.trim().replace("origin/", "");
+	}
+
+	// Fall back to checking if main or master exists
+	const branches = await getLocalBranches(pi);
+	if (branches.includes("main")) return "main";
+	if (branches.includes("master")) return "master";
+
+	return "main"; // Default fallback
+}
+
+/**
+ * Build the review prompt based on target
+ */
+async function buildReviewPrompt(
+	pi: ExtensionAPI,
+	target: ReviewTarget,
+): Promise<string> {
+	switch (target.type) {
+		case "uncommitted":
+			return UNCOMMITTED_PROMPT;
+
+		case "baseBranch": {
+			const mergeBase = await getMergeBase(pi, target.branch);
+			const basePrompt = mergeBase
+				? BASE_BRANCH_PROMPT_WITH_MERGE_BASE.replace(/{baseBranch}/g, target.branch).replace(/{mergeBaseSha}/g, mergeBase)
+				: BASE_BRANCH_PROMPT_FALLBACK.replace(/{branch}/g, target.branch);
+			return basePrompt;
+		}
+
+		case "commit":
+			if (target.title) {
+				return COMMIT_PROMPT_WITH_TITLE.replace("{sha}", target.sha).replace("{title}", target.title);
+			}
+			return COMMIT_PROMPT.replace("{sha}", target.sha);
+
+		case "pullRequest": {
+			const mergeBase = await getMergeBase(pi, target.baseBranch);
+			const basePrompt = mergeBase
+				? PULL_REQUEST_PROMPT
+						.replace(/{prNumber}/g, String(target.prNumber))
+						.replace(/{title}/g, target.title)
+						.replace(/{baseBranch}/g, target.baseBranch)
+						.replace(/{mergeBaseSha}/g, mergeBase)
+				: PULL_REQUEST_PROMPT_FALLBACK
+						.replace(/{prNumber}/g, String(target.prNumber))
+						.replace(/{title}/g, target.title)
+						.replace(/{baseBranch}/g, target.baseBranch);
+			return basePrompt;
+		}
+
+		case "folder":
+			return FOLDER_REVIEW_PROMPT.replace("{paths}", target.paths.join(", "));
+	}
+}
+
+/**
+ * Get user-facing hint for the review target
+ */
+function getUserFacingHint(target: ReviewTarget): string {
+	switch (target.type) {
+		case "uncommitted":
+			return "current changes";
+		case "baseBranch":
+			return `changes against '${target.branch}'`;
+		case "commit": {
+			const shortSha = target.sha.slice(0, 7);
+			return target.title ? `commit ${shortSha}: ${target.title}` : `commit ${shortSha}`;
+		}
+
+		case "pullRequest": {
+			const shortTitle = target.title.length > 30 ? target.title.slice(0, 27) + "..." : target.title;
+			return `PR #${target.prNumber}: ${shortTitle}`;
+		}
+
+		case "folder": {
+			const joined = target.paths.join(", ");
+			return joined.length > 40 ? `folders: ${joined.slice(0, 37)}...` : `folders: ${joined}`;
+		}
+	}
+}
+
+// Review preset options for the selector (keep this order stable)
+const REVIEW_PRESETS = [
+	{ value: "uncommitted", label: "Review uncommitted changes", description: "" },
+	{ value: "baseBranch", label: "Review against a base branch", description: "(local)" },
+	{ value: "commit", label: "Review a commit", description: "" },
+	{ value: "pullRequest", label: "Review a pull request", description: "(GitHub PR)" },
+	{ value: "folder", label: "Review a folder (or more)", description: "(snapshot, not diff)" },
+] as const;
+
+const TOGGLE_CUSTOM_INSTRUCTIONS_VALUE = "toggleCustomInstructions" as const;
+type ReviewPresetValue =
+	| (typeof REVIEW_PRESETS)[number]["value"]
+	| typeof TOGGLE_CUSTOM_INSTRUCTIONS_VALUE;
+
+export default function reviewExtension(pi: ExtensionAPI) {
+	function persistReviewSettings() {
+		pi.appendEntry(REVIEW_SETTINGS_TYPE, {
+			customInstructions: reviewCustomInstructions,
+		});
+	}
+
+	function setReviewCustomInstructions(instructions: string | undefined) {
+		reviewCustomInstructions = instructions?.trim() || undefined;
+		persistReviewSettings();
+	}
+
+	function applyAllReviewState(ctx: ExtensionContext) {
+		applyReviewSettings(ctx);
+		applyReviewState(ctx);
+	}
+
+	async function ensureGithubCliReady(ctx: ExtensionContext): Promise<boolean> {
+		const ghVersion = await pi.exec("gh", ["--version"]);
+		if (ghVersion.code !== 0) {
+			ctx.ui.notify(`PR review requires GitHub CLI (\`gh\`). ${GH_SETUP_INSTRUCTIONS}`, "error");
+			return false;
+		}
+
+		const ghAuthStatus = await pi.exec("gh", ["auth", "status"]);
+		if (ghAuthStatus.code !== 0) {
+			ctx.ui.notify(
+				"GitHub CLI is installed, but you're not signed in. Run `gh auth login`, then verify with `gh auth status`.",
+				"error",
+			);
+			return false;
+		}
+
+		return true;
+	}
+
+	async function resolvePullRequestTarget(
+		ctx: ExtensionContext,
+		ref: string,
+		options: { skipInitialPendingChangesCheck?: boolean } = {},
+	): Promise<ReviewTarget | null> {
+		if (!(await ensureGithubCliReady(ctx))) {
+			return null;
+		}
+
+		if (!options.skipInitialPendingChangesCheck && (await hasPendingChanges(pi))) {
+			ctx.ui.notify(PR_CHECKOUT_BLOCKED_BY_PENDING_CHANGES_MESSAGE, "error");
+			return null;
+		}
+
+		const prNumber = parsePrReference(ref);
+		if (!prNumber) {
+			ctx.ui.notify("Invalid PR reference. Enter a number or GitHub PR URL.", "error");
+			return null;
+		}
+
+		ctx.ui.notify(`Fetching PR #${prNumber} info...`, "info");
+		const prInfo = await getPrInfo(pi, prNumber);
+
+		if (!prInfo) {
+			ctx.ui.notify(
+				`Could not fetch PR #${prNumber}. Make sure it exists and your GitHub auth has access (check with \`gh auth status\`).`,
+				"error",
+			);
+			return null;
+		}
+
+		// Re-check right before checkout to avoid switching branches with newly introduced changes.
+		if (await hasPendingChanges(pi)) {
+			ctx.ui.notify(PR_CHECKOUT_BLOCKED_BY_PENDING_CHANGES_MESSAGE, "error");
+			return null;
+		}
+
+		ctx.ui.notify(`Checking out PR #${prNumber}...`, "info");
+		const checkoutResult = await checkoutPr(pi, prNumber);
+
+		if (!checkoutResult.success) {
+			ctx.ui.notify(`Failed to checkout PR: ${checkoutResult.error}`, "error");
+			return null;
+		}
+
+		ctx.ui.notify(`Checked out PR #${prNumber} (${prInfo.headBranch})`, "info");
+
+		return {
+			type: "pullRequest",
+			prNumber,
+			baseBranch: prInfo.baseBranch,
+			title: prInfo.title,
+		};
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		applyAllReviewState(ctx);
+	});
+
+
+	pi.on("session_tree", (_event, ctx) => {
+		applyAllReviewState(ctx);
+	});
+
+	/**
+	 * Determine the smart default review type based on git state
+	 */
+	async function getSmartDefault(): Promise<"uncommitted" | "baseBranch" | "commit"> {
+		// Priority 1: If there are uncommitted changes, default to reviewing them
+		if (await hasUncommittedChanges(pi)) {
+			return "uncommitted";
+		}
+
+		// Priority 2: If on a feature branch (not the default branch), default to PR-style review
+		const currentBranch = await getCurrentBranch(pi);
+		const defaultBranch = await getDefaultBranch(pi);
+		if (currentBranch && currentBranch !== defaultBranch) {
+			return "baseBranch";
+		}
+
+		// Priority 3: Default to reviewing a specific commit
+		return "commit";
+	}
+
+	/**
+	 * Show the review preset selector
+	 */
+	async function showReviewSelector(ctx: ExtensionContext): Promise<ReviewTarget | null> {
+		// Determine smart default (but keep the list order stable)
+		const smartDefault = await getSmartDefault();
+		const presetItems: SelectItem[] = REVIEW_PRESETS.map((preset) => ({
+			value: preset.value,
+			label: preset.label,
+			description: preset.description,
+		}));
+		const smartDefaultIndex = presetItems.findIndex((item) => item.value === smartDefault);
+
+		while (true) {
+			const customInstructionsLabel = reviewCustomInstructions
+				? "Remove custom review instructions"
+				: "Add custom review instructions";
+			const customInstructionsDescription = reviewCustomInstructions
+				? "(currently set)"
+				: "(applies to all review modes)";
+			const items: SelectItem[] = [
+				...presetItems,
+				{
+					value: TOGGLE_CUSTOM_INSTRUCTIONS_VALUE,
+					label: customInstructionsLabel,
+					description: customInstructionsDescription,
+				},
+			];
+
+			const result = await ctx.ui.custom<ReviewPresetValue | null>((tui, theme, _kb, done) => {
+				const container = new Container();
+				container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+				container.addChild(new Text(theme.fg("accent", theme.bold("Select a review preset"))));
+
+				const selectList = new SelectList(items, Math.min(items.length, 10), {
+					selectedPrefix: (text) => theme.fg("accent", text),
+					selectedText: (text) => theme.fg("accent", text),
+					description: (text) => theme.fg("muted", text),
+					scrollInfo: (text) => theme.fg("dim", text),
+					noMatch: (text) => theme.fg("warning", text),
+				});
+
+				// Preselect the smart default without reordering the list
+				if (smartDefaultIndex >= 0) {
+					selectList.setSelectedIndex(smartDefaultIndex);
+				}
+
+				selectList.onSelect = (item) => done(item.value as ReviewPresetValue);
+				selectList.onCancel = () => done(null);
+
+				container.addChild(selectList);
+				container.addChild(new Text(theme.fg("dim", "Press enter to confirm or esc to go back")));
+				container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+
+				return {
+					render(width: number) {
+						return container.render(width);
+					},
+					invalidate() {
+						container.invalidate();
+					},
+					handleInput(data: string) {
+						selectList.handleInput(data);
+						tui.requestRender();
+					},
+				};
+			});
+
+			if (!result) return null;
+
+			if (result === TOGGLE_CUSTOM_INSTRUCTIONS_VALUE) {
+				if (reviewCustomInstructions) {
+					setReviewCustomInstructions(undefined);
+					ctx.ui.notify("Custom review instructions removed", "info");
+					continue;
+				}
+
+				const customInstructions = await ctx.ui.editor(
+					"Enter custom review instructions (applies to all review modes):",
+					"",
+				);
+
+				if (!customInstructions?.trim()) {
+					ctx.ui.notify("Custom review instructions not changed", "info");
+					continue;
+				}
+
+				setReviewCustomInstructions(customInstructions);
+				ctx.ui.notify("Custom review instructions saved", "info");
+				continue;
+			}
+
+			// Handle each preset type
+			switch (result) {
+				case "uncommitted":
+					return { type: "uncommitted" };
+
+				case "baseBranch": {
+					const target = await showBranchSelector(ctx);
+					if (target) return target;
+					break;
+				}
+
+				case "commit": {
+					const target = await showCommitSelector(ctx);
+					if (target) return target;
+					break;
+				}
+
+				case "folder": {
+					const target = await showFolderInput(ctx);
+					if (target) return target;
+					break;
+				}
+
+				case "pullRequest": {
+					const target = await showPrInput(ctx);
+					if (target) return target;
+					break;
+				}
+
+				default:
+					return null;
+			}
+		}
+	}
+
+	/**
+	 * Show branch selector for base branch review
+	 */
+	async function showBranchSelector(ctx: ExtensionContext): Promise<ReviewTarget | null> {
+		const branches = await getLocalBranches(pi);
+		const currentBranch = await getCurrentBranch(pi);
+		const defaultBranch = await getDefaultBranch(pi);
+
+		// Never offer the current branch as a base branch (reviewing against itself is meaningless).
+		const candidateBranches = currentBranch ? branches.filter((b) => b !== currentBranch) : branches;
+
+		if (candidateBranches.length === 0) {
+			ctx.ui.notify(
+				currentBranch ? `No other branches found (current branch: ${currentBranch})` : "No branches found",
+				"error",
+			);
+			return null;
+		}
+
+		// Sort branches with default branch first
+		const sortedBranches = candidateBranches.sort((a, b) => {
+			if (a === defaultBranch) return -1;
+			if (b === defaultBranch) return 1;
+			return a.localeCompare(b);
+		});
+
+		const items: SelectItem[] = sortedBranches.map((branch) => ({
+			value: branch,
+			label: branch,
+			description: branch === defaultBranch ? "(default)" : "",
+		}));
+
+		const result = await ctx.ui.custom<string | null>((tui, theme, keybindings, done) => {
+			const container = new Container();
+			container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+			container.addChild(new Text(theme.fg("accent", theme.bold("Select base branch"))));
+
+			const searchInput = new Input();
+			container.addChild(searchInput);
+			container.addChild(new Spacer(1));
+
+			const listContainer = new Container();
+			container.addChild(listContainer);
+			container.addChild(new Text(theme.fg("dim", "Type to filter • enter to select • esc to cancel")));
+			container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+
+			let filteredItems = items;
+			let selectList: SelectList | null = null;
+
+			const updateList = () => {
+				listContainer.clear();
+				if (filteredItems.length === 0) {
+					listContainer.addChild(new Text(theme.fg("warning", "  No matching branches")));
+					selectList = null;
+					return;
+				}
+
+				selectList = new SelectList(filteredItems, Math.min(filteredItems.length, 10), {
+					selectedPrefix: (text) => theme.fg("accent", text),
+					selectedText: (text) => theme.fg("accent", text),
+					description: (text) => theme.fg("muted", text),
+					scrollInfo: (text) => theme.fg("dim", text),
+					noMatch: (text) => theme.fg("warning", text),
+				});
+
+				selectList.onSelect = (item) => done(item.value);
+				selectList.onCancel = () => done(null);
+				listContainer.addChild(selectList);
+			};
+
+			const applyFilter = () => {
+				const query = searchInput.getValue();
+				filteredItems = query
+					? fuzzyFilter(items, query, (item) => `${item.label} ${item.value} ${item.description ?? ""}`)
+					: items;
+				updateList();
+			};
+
+			applyFilter();
+
+			return {
+				render(width: number) {
+					return container.render(width);
+				},
+				invalidate() {
+					container.invalidate();
+				},
+				handleInput(data: string) {
+					if (
+						keybindings.matches(data, "tui.select.up") ||
+						keybindings.matches(data, "tui.select.down") ||
+						keybindings.matches(data, "tui.select.confirm") ||
+						keybindings.matches(data, "tui.select.cancel")
+					) {
+						if (selectList) {
+							selectList.handleInput(data);
+						} else if (keybindings.matches(data, "tui.select.cancel")) {
+							done(null);
+						}
+						tui.requestRender();
+						return;
+					}
+
+					searchInput.handleInput(data);
+					applyFilter();
+					tui.requestRender();
+				},
+			};
+		});
+
+		if (!result) return null;
+		return { type: "baseBranch", branch: result };
+	}
+
+	/**
+	 * Show commit selector
+	 */
+	async function showCommitSelector(ctx: ExtensionContext): Promise<ReviewTarget | null> {
+		const commits = await getRecentCommits(pi, 20);
+
+		if (commits.length === 0) {
+			ctx.ui.notify("No commits found", "error");
+			return null;
+		}
+
+		const items: SelectItem[] = commits.map((commit) => ({
+			value: commit.sha,
+			label: `${commit.sha.slice(0, 7)} ${commit.title}`,
+			description: "",
+		}));
+
+		const result = await ctx.ui.custom<{ sha: string; title: string } | null>((tui, theme, keybindings, done) => {
+			const container = new Container();
+			container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+			container.addChild(new Text(theme.fg("accent", theme.bold("Select commit to review"))));
+
+			const searchInput = new Input();
+			container.addChild(searchInput);
+			container.addChild(new Spacer(1));
+
+			const listContainer = new Container();
+			container.addChild(listContainer);
+			container.addChild(new Text(theme.fg("dim", "Type to filter • enter to select • esc to cancel")));
+			container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
+
+			let filteredItems = items;
+			let selectList: SelectList | null = null;
+
+			const updateList = () => {
+				listContainer.clear();
+				if (filteredItems.length === 0) {
+					listContainer.addChild(new Text(theme.fg("warning", "  No matching commits")));
+					selectList = null;
+					return;
+				}
+
+				selectList = new SelectList(filteredItems, Math.min(filteredItems.length, 10), {
+					selectedPrefix: (text) => theme.fg("accent", text),
+					selectedText: (text) => theme.fg("accent", text),
+					description: (text) => theme.fg("muted", text),
+					scrollInfo: (text) => theme.fg("dim", text),
+					noMatch: (text) => theme.fg("warning", text),
+				});
+
+				selectList.onSelect = (item) => {
+					const commit = commits.find((c) => c.sha === item.value);
+					if (commit) {
+						done(commit);
+					} else {
+						done(null);
+					}
+				};
+				selectList.onCancel = () => done(null);
+				listContainer.addChild(selectList);
+			};
+
+			const applyFilter = () => {
+				const query = searchInput.getValue();
+				filteredItems = query
+					? fuzzyFilter(items, query, (item) => `${item.label} ${item.value} ${item.description ?? ""}`)
+					: items;
+				updateList();
+			};
+
+			applyFilter();
+
+			return {
+				render(width: number) {
+					return container.render(width);
+				},
+				invalidate() {
+					container.invalidate();
+				},
+				handleInput(data: string) {
+					if (
+						keybindings.matches(data, "tui.select.up") ||
+						keybindings.matches(data, "tui.select.down") ||
+						keybindings.matches(data, "tui.select.confirm") ||
+						keybindings.matches(data, "tui.select.cancel")
+					) {
+						if (selectList) {
+							selectList.handleInput(data);
+						} else if (keybindings.matches(data, "tui.select.cancel")) {
+							done(null);
+						}
+						tui.requestRender();
+						return;
+					}
+
+					searchInput.handleInput(data);
+					applyFilter();
+					tui.requestRender();
+				},
+			};
+		});
+
+		if (!result) return null;
+		return { type: "commit", sha: result.sha, title: result.title };
+	}
+
+
+	function parseReviewPaths(value: string): string[] {
+		return value
+			.split(/\s+/)
+			.map((item) => item.trim())
+			.filter((item) => item.length > 0);
+	}
+
+	/**
+	 * Show folder input
+	 */
+	async function showFolderInput(ctx: ExtensionContext): Promise<ReviewTarget | null> {
+		const result = await ctx.ui.editor(
+			"Enter folders/files to review (space-separated or one per line):",
+			".",
+		);
+
+		if (!result?.trim()) return null;
+		const paths = parseReviewPaths(result);
+		if (paths.length === 0) return null;
+
+		return { type: "folder", paths };
+	}
+
+	/**
+	 * Show PR input and handle checkout
+	 */
+	async function showPrInput(ctx: ExtensionContext): Promise<ReviewTarget | null> {
+		// First check for pending changes that would prevent branch switching
+		if (await hasPendingChanges(pi)) {
+			ctx.ui.notify(PR_CHECKOUT_BLOCKED_BY_PENDING_CHANGES_MESSAGE, "error");
+			return null;
+		}
+
+		// Get PR reference from user
+		const prRef = await ctx.ui.editor(
+			"Enter PR number or URL (e.g. 123 or https://github.com/owner/repo/pull/123):",
+			"",
+		);
+
+		if (!prRef?.trim()) return null;
+
+		return await resolvePullRequestTarget(ctx, prRef, { skipInitialPendingChangesCheck: true });
+	}
+
+	/**
+	 * Execute the review
+	 */
+	async function executeReview(
+		ctx: ExtensionCommandContext,
+		target: ReviewTarget,
+		useFreshSession: boolean,
+		options?: { extraInstruction?: string },
+	): Promise<boolean> {
+		// Check if we're already in a review
+		if (reviewOriginId) {
+			ctx.ui.notify("Already in a review. Use /end-review to finish first.", "warning");
+			return false;
+		}
+
+		// Handle fresh session mode
+		if (useFreshSession) {
+			// Store current position (where we'll return to).
+			// In an empty session there is no leaf yet, so create a lightweight anchor first.
+			let originId = ctx.sessionManager.getLeafId() ?? undefined;
+			if (!originId) {
+				pi.appendEntry(REVIEW_ANCHOR_TYPE, { createdAt: new Date().toISOString() });
+				originId = ctx.sessionManager.getLeafId() ?? undefined;
+			}
+			if (!originId) {
+				ctx.ui.notify("Failed to determine review origin.", "error");
+				return false;
+			}
+			reviewOriginId = originId;
+
+			// Keep a local copy so session_tree events during navigation don't wipe it
+			const lockedOriginId = originId;
+
+			// Find the first user message in the session.
+			// If none exists (e.g. brand-new session), we'll stay on the current leaf.
+			const entries = ctx.sessionManager.getEntries();
+			const firstUserMessage = entries.find(
+				(e) => e.type === "message" && e.message.role === "user",
+			);
+
+			if (firstUserMessage) {
+				// Navigate to first user message to create a new branch from that point
+				// Label it as "code-review" so it's visible in the tree
+				try {
+					const result = await ctx.navigateTree(firstUserMessage.id, { summarize: false, label: "code-review" });
+					if (result.cancelled) {
+						reviewOriginId = undefined;
+						return false;
+					}
+				} catch (error) {
+					// Clean up state if navigation fails
+					reviewOriginId = undefined;
+					ctx.ui.notify(`Failed to start review: ${error instanceof Error ? error.message : String(error)}`, "error");
+					return false;
+				}
+
+				// Clear the editor (navigating to user message fills it with the message text)
+				ctx.ui.setEditorText("");
+			}
+
+			// Restore origin after navigation events (session_tree can reset it)
+			reviewOriginId = lockedOriginId;
+
+			// Show widget indicating review is active
+			setReviewWidget(ctx, true);
+
+			// Persist review state so tree navigation can restore/reset it
+			pi.appendEntry(REVIEW_STATE_TYPE, { active: true, originId: lockedOriginId });
+		}
+
+		const prompt = await buildReviewPrompt(pi, target);
+		const hint = getUserFacingHint(target);
+		const projectGuidelines = await loadProjectReviewGuidelines(ctx.cwd);
+
+		// Combine the review rubric with the specific prompt
+		let fullPrompt = `${REVIEW_RUBRIC}\n\n---\n\nPlease perform a code review with the following focus:\n\n${prompt}`;
+
+		if (reviewCustomInstructions) {
+			fullPrompt += `\n\nShared custom review instructions (applies to all reviews):\n\n${reviewCustomInstructions}`;
+		}
+
+		if (options?.extraInstruction?.trim()) {
+			fullPrompt += `\n\nAdditional user-provided review instruction:\n\n${options.extraInstruction.trim()}`;
+		}
+
+		if (projectGuidelines) {
+			fullPrompt += `\n\nThis project has additional instructions for code reviews:\n\n${projectGuidelines}`;
+		}
+
+		const modeHint = useFreshSession ? " (fresh session)" : "";
+		ctx.ui.notify(`Starting review: ${hint}${modeHint}`, "info");
+
+		// Send as a user message that triggers a turn
+		pi.sendUserMessage(fullPrompt);
+		return true;
+	}
+
+	/**
+	 * Parse command arguments for direct invocation
+	 * Returns the target or a special marker for PR that needs async handling
+	 */
+	type ParsedReviewArgs = {
+		target: ReviewTarget | { type: "pr"; ref: string } | null;
+		extraInstruction?: string;
+		error?: string;
+	};
+
+	function tokenizeArgs(value: string): string[] {
+		const tokens: string[] = [];
+		let current = "";
+		let quote: '"' | "'" | null = null;
+
+		for (let i = 0; i < value.length; i++) {
+			const char = value[i];
+
+			if (quote) {
+				if (char === "\\" && i + 1 < value.length) {
+					current += value[i + 1];
+					i += 1;
+					continue;
+				}
+				if (char === quote) {
+					quote = null;
+					continue;
+				}
+				current += char;
+				continue;
+			}
+
+			if (char === '"' || char === "'") {
+				quote = char;
+				continue;
+			}
+
+			if (/\s/.test(char)) {
+				if (current.length > 0) {
+					tokens.push(current);
+					current = "";
+				}
+				continue;
+			}
+
+			current += char;
+		}
+
+		if (current.length > 0) {
+			tokens.push(current);
+		}
+
+		return tokens;
+	}
+
+	function parseArgs(args: string | undefined): ParsedReviewArgs {
+		if (!args?.trim()) return { target: null };
+
+		const rawParts = tokenizeArgs(args.trim());
+		const parts: string[] = [];
+		let extraInstruction: string | undefined;
+
+		for (let i = 0; i < rawParts.length; i++) {
+			const part = rawParts[i];
+			if (part === "--extra") {
+				const next = rawParts[i + 1];
+				if (!next) {
+					return { target: null, error: "Missing value for --extra" };
+				}
+				extraInstruction = next;
+				i += 1;
+				continue;
+			}
+
+			if (part.startsWith("--extra=")) {
+				extraInstruction = part.slice("--extra=".length);
+				continue;
+			}
+
+			parts.push(part);
+		}
+
+		if (parts.length === 0) {
+			return { target: null, extraInstruction };
+		}
+
+		const subcommand = parts[0]?.toLowerCase();
+
+		switch (subcommand) {
+			case "uncommitted":
+				return { target: { type: "uncommitted" }, extraInstruction };
+
+			case "branch": {
+				const branch = parts[1];
+				if (!branch) return { target: null, extraInstruction };
+				return { target: { type: "baseBranch", branch }, extraInstruction };
+			}
+
+			case "commit": {
+				const sha = parts[1];
+				if (!sha) return { target: null, extraInstruction };
+				const title = parts.slice(2).join(" ") || undefined;
+				return { target: { type: "commit", sha, title }, extraInstruction };
+			}
+
+
+			case "folder": {
+				const paths = parseReviewPaths(parts.slice(1).join(" "));
+				if (paths.length === 0) return { target: null, extraInstruction };
+				return { target: { type: "folder", paths }, extraInstruction };
+			}
+
+			case "pr": {
+				const ref = parts[1];
+				if (!ref) return { target: null, extraInstruction };
+				return { target: { type: "pr", ref }, extraInstruction };
+			}
+
+			default:
+				return { target: null, extraInstruction };
+		}
+	}
+
+	/**
+	 * Handle PR checkout and return a ReviewTarget (or null on failure)
+	 */
+	async function handlePrCheckout(ctx: ExtensionContext, ref: string): Promise<ReviewTarget | null> {
+		return await resolvePullRequestTarget(ctx, ref);
+	}
+
+	// Register the /review command
+	pi.registerCommand("review", {
+		description: "Review code changes (PR, uncommitted, branch, commit, or folder)",
+		handler: async (args, ctx) => {
+			if (!ctx.hasUI) {
+				ctx.ui.notify("Review requires interactive mode", "error");
+				return;
+			}
+
+			// Check if we're already in a review
+			if (reviewOriginId) {
+				ctx.ui.notify("Already in a review. Use /end-review to finish first.", "warning");
+				return;
+			}
+
+			// Check if we're in a git repository
+			const { code } = await pi.exec("git", ["rev-parse", "--git-dir"]);
+			if (code !== 0) {
+				ctx.ui.notify("Not a git repository", "error");
+				return;
+			}
+
+			// Try to parse direct arguments
+			let target: ReviewTarget | null = null;
+			let fromSelector = false;
+			let extraInstruction: string | undefined;
+			const parsed = parseArgs(args);
+			if (parsed.error) {
+				ctx.ui.notify(parsed.error, "error");
+				return;
+			}
+			extraInstruction = parsed.extraInstruction?.trim() || undefined;
+
+			if (parsed.target) {
+				if (parsed.target.type === "pr") {
+					// Handle PR checkout (async operation)
+					target = await handlePrCheckout(ctx, parsed.target.ref);
+					if (!target) {
+						ctx.ui.notify("PR review failed. Returning to review menu.", "warning");
+					}
+				} else {
+					target = parsed.target;
+				}
+			}
+
+			// If no args or invalid args, show selector
+			if (!target) {
+				fromSelector = true;
+			}
+
+			while (true) {
+				if (!target && fromSelector) {
+					target = await showReviewSelector(ctx);
+				}
+
+				if (!target) {
+					ctx.ui.notify("Review cancelled", "info");
+					return;
+				}
+
+				// Determine if we should use fresh session mode
+				// Check if this is a new session (no messages yet)
+				const entries = ctx.sessionManager.getEntries();
+				const messageCount = entries.filter((e) => e.type === "message").length;
+
+				// In an empty session, default to fresh review mode so /end-review works consistently.
+				let useFreshSession = messageCount === 0;
+
+				if (messageCount > 0) {
+					// Existing session - ask user which mode they want
+					const choice = await ctx.ui.select("Start review in:", ["Empty branch", "Current session"]);
+
+					if (choice === undefined) {
+						if (fromSelector) {
+							target = null;
+							continue;
+						}
+						ctx.ui.notify("Review cancelled", "info");
+						return;
+					}
+
+					useFreshSession = choice === "Empty branch";
+				}
+
+				await executeReview(ctx, target, useFreshSession, { extraInstruction });
+				return;
+			}
+		},
+	});
+
+	// Custom prompt for review summaries - focuses on preserving actionable findings
+	const REVIEW_SUMMARY_PROMPT = `We are leaving a code-review branch and returning to the main coding branch.
+Create a structured handoff that can be used immediately to implement fixes.
+
+You MUST summarize the review that happened in this branch so findings can be acted on.
+Do not omit findings: include every actionable issue that was identified.
+
+Required sections (in order):
+
+## Review Scope
+- What was reviewed (files/paths, changes, and scope)
+
+## Verdict
+- "correct" or "needs attention"
+
+## Findings
+For EACH finding, include:
+- Priority tag ([P0]..[P3]) and short title
+- File location (\`path/to/file.ext:line\`)
+- Why it matters (brief)
+- What should change (brief, actionable)
+
+## Fix Queue
+1. Ordered implementation checklist (highest priority first)
+
+## Constraints & Preferences
+- Any constraints or preferences mentioned during review
+- Or "(none)"
+
+## Human Reviewer Callouts (Non-Blocking)
+Include only applicable callouts (no yes/no lines):
+- **This change adds a database migration:** <files/details>
+- **This change introduces a new dependency:** <package(s)/details>
+- **This change changes a dependency (or the lockfile):** <files/package(s)/details>
+- **This change modifies auth/permission behavior:** <what changed and where>
+- **This change introduces backwards-incompatible public schema/API/contract changes:** <what changed and where>
+- **This change includes irreversible or destructive operations:** <operation and scope>
+
+If none apply, write "- (none)".
+
+These are informational callouts for humans and are not fix items by themselves.
+
+Preserve exact file paths, function names, and error messages where available.`;
+
+	const REVIEW_FIX_FINDINGS_PROMPT = `Use the latest review summary in this session and implement the review findings now.
+
+Instructions:
+1. Treat the summary's Findings/Fix Queue as a checklist.
+2. Fix in priority order: P0, P1, then P2 (include P3 if quick and safe).
+3. If a finding is invalid/already fixed/not possible right now, briefly explain why and continue.
+4. Treat "Human Reviewer Callouts (Non-Blocking)" as informational only; do not convert them into fix tasks unless there is a separate explicit finding.
+5. Follow fail-fast error handling: do not add local catch/fallback recovery unless this scope is an explicit boundary that can safely translate the failure.
+6. If you add or keep a \`try/catch\`, explain the expected failure mode and either rethrow with context or return a boundary-safe error response.
+7. JSON parsing/decoding should fail loudly by default; avoid silent fallback parsing.
+8. Run relevant tests/checks for touched code where practical.
+9. End with: fixed items, deferred/skipped items (with reasons), and verification results.`;
+
+	type EndReviewAction = "returnOnly" | "returnAndFix" | "returnAndSummarize";
+	type EndReviewActionResult = "ok" | "cancelled" | "error";
+	type EndReviewActionOptions = {
+		showSummaryLoader?: boolean;
+		notifySuccess?: boolean;
+	};
+
+	function getActiveReviewOrigin(ctx: ExtensionContext): string | undefined {
+		if (reviewOriginId) {
+			return reviewOriginId;
+		}
+
+		const state = getReviewState(ctx);
+		if (state?.active && state.originId) {
+			reviewOriginId = state.originId;
+			return reviewOriginId;
+		}
+
+		if (state?.active) {
+			setReviewWidget(ctx, false);
+			pi.appendEntry(REVIEW_STATE_TYPE, { active: false });
+			ctx.ui.notify("Review state was missing origin info; cleared review status.", "warning");
+		}
+
+		return undefined;
+	}
+
+	function clearReviewState(ctx: ExtensionContext) {
+		setReviewWidget(ctx, false);
+		reviewOriginId = undefined;
+		pi.appendEntry(REVIEW_STATE_TYPE, { active: false });
+	}
+
+	async function navigateWithSummary(
+		ctx: ExtensionCommandContext,
+		originId: string,
+		showLoader: boolean,
+	): Promise<{ cancelled: boolean; error?: string } | null> {
+		if (showLoader && ctx.hasUI) {
+			return ctx.ui.custom<{ cancelled: boolean; error?: string } | null>((tui, theme, _kb, done) => {
+				const loader = new BorderedLoader(tui, theme, "Returning and summarizing review branch...");
+				loader.onAbort = () => done(null);
+
+				ctx.navigateTree(originId, {
+					summarize: true,
+					customInstructions: REVIEW_SUMMARY_PROMPT,
+					replaceInstructions: true,
+				})
+					.then(done)
+					.catch((err) => done({ cancelled: false, error: err instanceof Error ? err.message : String(err) }));
+
+				return loader;
+			});
+		}
+
+		try {
+			return await ctx.navigateTree(originId, {
+				summarize: true,
+				customInstructions: REVIEW_SUMMARY_PROMPT,
+				replaceInstructions: true,
+			});
+		} catch (error) {
+			return { cancelled: false, error: error instanceof Error ? error.message : String(error) };
+		}
+	}
+
+	async function executeEndReviewAction(
+		ctx: ExtensionCommandContext,
+		action: EndReviewAction,
+		options: EndReviewActionOptions = {},
+	): Promise<EndReviewActionResult> {
+		const originId = getActiveReviewOrigin(ctx);
+		if (!originId) {
+			if (!getReviewState(ctx)?.active) {
+				ctx.ui.notify("Not in a review branch (use /review first, or review was started in current session mode)", "info");
+			}
+			return "error";
+		}
+
+		const notifySuccess = options.notifySuccess ?? true;
+
+		if (action === "returnOnly") {
+			try {
+				const result = await ctx.navigateTree(originId, { summarize: false });
+				if (result.cancelled) {
+					ctx.ui.notify("Navigation cancelled. Use /end-review to try again.", "info");
+					return "cancelled";
+				}
+			} catch (error) {
+				ctx.ui.notify(`Failed to return: ${error instanceof Error ? error.message : String(error)}`, "error");
+				return "error";
+			}
+
+			clearReviewState(ctx);
+			if (notifySuccess) {
+				ctx.ui.notify("Review complete! Returned to original position.", "info");
+			}
+			return "ok";
+		}
+
+		const summaryResult = await navigateWithSummary(ctx, originId, options.showSummaryLoader ?? false);
+		if (summaryResult === null) {
+			ctx.ui.notify("Summarization cancelled. Use /end-review to try again.", "info");
+			return "cancelled";
+		}
+
+		if (summaryResult.error) {
+			ctx.ui.notify(`Summarization failed: ${summaryResult.error}`, "error");
+			return "error";
+		}
+
+		if (summaryResult.cancelled) {
+			ctx.ui.notify("Navigation cancelled. Use /end-review to try again.", "info");
+			return "cancelled";
+		}
+
+		clearReviewState(ctx);
+
+		if (action === "returnAndSummarize") {
+			if (!ctx.ui.getEditorText().trim()) {
+				ctx.ui.setEditorText("Act on the review findings");
+			}
+			if (notifySuccess) {
+				ctx.ui.notify("Review complete! Returned and summarized.", "info");
+			}
+			return "ok";
+		}
+
+		pi.sendUserMessage(REVIEW_FIX_FINDINGS_PROMPT, { deliverAs: "followUp" });
+		if (notifySuccess) {
+			ctx.ui.notify("Review complete! Returned and queued a follow-up to fix findings.", "info");
+		}
+		return "ok";
+	}
+
+	async function runEndReview(ctx: ExtensionCommandContext): Promise<void> {
+		if (!ctx.hasUI) {
+			ctx.ui.notify("End-review requires interactive mode", "error");
+			return;
+		}
+
+
+		if (endReviewInProgress) {
+			ctx.ui.notify("/end-review is already running", "info");
+			return;
+		}
+
+		endReviewInProgress = true;
+		try {
+			const choice = await ctx.ui.select("Finish review:", [
+				"Return only",
+				"Return and fix findings",
+				"Return and summarize",
+			]);
+
+			if (choice === undefined) {
+				ctx.ui.notify("Cancelled. Use /end-review to try again.", "info");
+				return;
+			}
+
+			const action: EndReviewAction =
+				choice === "Return and fix findings"
+					? "returnAndFix"
+					: choice === "Return and summarize"
+						? "returnAndSummarize"
+						: "returnOnly";
+
+			await executeEndReviewAction(ctx, action, {
+				showSummaryLoader: true,
+				notifySuccess: true,
+			});
+		} finally {
+			endReviewInProgress = false;
+		}
+	}
+
+	// Register the /end-review command
+	pi.registerCommand("end-review", {
+		description: "Complete review and return to original position",
+		handler: async (_args, ctx) => {
+			await runEndReview(ctx);
+		},
+	});
+}

--- a/dots/.pi/agent/settings.json
+++ b/dots/.pi/agent/settings.json
@@ -1,16 +1,19 @@
 {
-    "lastChangelogVersion": "0.74.0",
-    "defaultProvider": "openai-codex",
-    "defaultModel": "gpt-5.4",
-    "theme": "neverforest",
-    "packages": ["~/code/rmarganti/anno/pi/anno-review"],
-    "defaultThinkingLevel": "medium",
-    "enabledModels": [
-        "github-copilot/claude-haiku-4.5",
-        "github-copilot/claude-sonnet-4.6",
-        "openai-codex/gpt-5.5",
-        "openai-codex/gpt-5.4",
-        "openai-codex/gpt-5.4-mini"
-    ]
+  "lastChangelogVersion": "0.79.1",
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.5",
+  "theme": "neverforest",
+  "packages": [
+    "~/code/rmarganti/anno/pi/anno-review",
+    "npm:pi-autoresearch"
+  ],
+  "defaultThinkingLevel": "medium",
+  "enabledModels": [
+    "github-copilot/claude-haiku-4.5",
+    "github-copilot/claude-sonnet-4.6",
+    "openai-codex/gpt-5.5",
+    "openai-codex/gpt-5.4",
+    "openai-codex/gpt-5.4-mini"
+  ],
+  "hideThinkingBlock": false
 }
-


### PR DESCRIPTION
## Summary

Reduces interactive bash startup from ~206ms to ~39ms by eliminating expensive subprocess forks on every shell start.

## Changes

### Lazy-load pyenv (~127ms saved)
Replace `eval "$(pyenv init -)"` with a shell function stub. The real init runs only on the first `pyenv` call. `$PYENV_ROOT/bin` and `$PYENV_ROOT/shims` are added to `PATH` immediately so shims still work from the start.

### Cache tool init outputs (~50ms saved)
`gh`, `starship`, `fzf`, and `zoxide` all fork subprocesses and generate static bash code on every shell start. Each is now cached to `~/.cache/<tool>_init.bash` and sourced directly. Caches are auto-invalidated when the tool binary has a newer mtime than the cache file — no manual management needed.

### Replace `mise activate bash` with shims mode (~23ms saved)
`eval "$(mise activate bash)"` generates 6.5KB of complex shell code that takes ~23ms to source. Shims mode (`export PATH="$HOME/.local/share/mise/shims:$PATH"`) is a single line. Tools still resolve the correct version via shims (`.nvmrc` / `.tool-versions` are respected). The only loss is the PROMPT_COMMAND banner when switching versions on `cd` — the right version is still used.

### Minor cleanups
- Remove duplicate `VISUAL`/`EDITOR` exports (already set in `.bash_profile`)
- Simplify git-completion source (drop redundant `command -v git` check)

## Metric

| | Time |
|---|---|
| Before | ~206ms |
| After | ~39ms |
| **Improvement** | **−81%** |

## New machine setup

Run once to pre-generate caches (auto-regenerate on tool updates after that):

```bash
mkdir -p ~/.cache
gh completion -s bash > ~/.cache/gh_completion.bash
starship init bash --print-full-init > ~/.cache/starship_init.bash
fzf --bash > ~/.cache/fzf_init.bash
zoxide init bash > ~/.cache/zoxide_init.bash
```

> **Note on mise:** shims mode loses the per-directory version-switch notification banner. If you want it back, change the mise section in `.bashrc` to `eval "$(mise activate bash)"`.