### PR TITLE
feat: add Neverforest theme for BB

### DIFF
--- a/dots/.bb/.gitignore
+++ b/dots/.bb/.gitignore
@@ -1,0 +1,6 @@
+# ~/.bb contains runtime state, credentials, logs, databases, and sessions.
+# Only explicitly allow portable configuration managed by this repository.
+*
+!.gitignore
+!theme/
+!theme/**

--- a/dots/.bb/theme/neverforest/neverforest-dark.json
+++ b/dots/.bb/theme/neverforest/neverforest-dark.json
@@ -1,0 +1,40 @@
+{
+  "name": "Neverforest Dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#1d2226",
+    "editor.foreground": "#d3c6aa",
+    "editorLineNumber.foreground": "#515a5b",
+    "editorLineNumber.activeForeground": "#aeccc6",
+    "editorCursor.foreground": "#d3c6aa",
+    "editor.selectionBackground": "#2a3137",
+    "editor.inactiveSelectionBackground": "#23292e",
+    "editor.lineHighlightBackground": "#181c1e",
+    "editorWhitespace.foreground": "#2b3238",
+    "editorIndentGuide.background1": "#30383f",
+    "editorIndentGuide.activeBackground1": "#515a5b",
+    "editorError.foreground": "#e67e80",
+    "editorWarning.foreground": "#dbbc7f",
+    "diffEditor.insertedTextBackground": "#222826",
+    "diffEditor.removedTextBackground": "#2b2020"
+  },
+  "tokenColors": [
+    { "scope": ["comment", "punctuation.definition.comment"], "settings": { "foreground": "#515a5b", "fontStyle": "italic" } },
+    { "scope": ["string", "constant.numeric", "constant.language", "constant.character"], "settings": { "foreground": "#bec8b5" } },
+    { "scope": ["entity.name.function", "support.function", "meta.function-call", "keyword.control"], "settings": { "foreground": "#a2ccae" } },
+    { "scope": ["entity.name.type", "entity.name.class", "support.type", "storage.type"], "settings": { "foreground": "#aeccc6" } },
+    { "scope": ["variable", "constant.other", "variable.parameter"], "settings": { "foreground": "#d3c6aa" } },
+    { "scope": ["variable.other.property", "variable.other.member", "entity.other.attribute-name"], "settings": { "foreground": "#bec8b5" } },
+    { "scope": ["keyword", "storage.modifier", "punctuation", "meta.brace"], "settings": { "foreground": "#77817d" } },
+    { "scope": ["keyword.operator", "constant.other.symbol"], "settings": { "foreground": "#9da9a0" } },
+    { "scope": ["entity.name.tag", "markup.heading"], "settings": { "foreground": "#a2ccae" } },
+    { "scope": ["markup.heading.1"], "settings": { "foreground": "#d699b6", "fontStyle": "bold" } },
+    { "scope": ["markup.heading.2"], "settings": { "foreground": "#dbbc7f", "fontStyle": "bold" } },
+    { "scope": ["markup.heading.3"], "settings": { "foreground": "#a2ccae", "fontStyle": "bold" } },
+    { "scope": ["markup.underline.link", "string.other.link"], "settings": { "foreground": "#87b5c1", "fontStyle": "underline" } },
+    { "scope": ["invalid", "invalid.illegal"], "settings": { "foreground": "#e67e80" } },
+    { "scope": ["markup.inserted"], "settings": { "foreground": "#a2ccae" } },
+    { "scope": ["markup.deleted"], "settings": { "foreground": "#e67e80" } },
+    { "scope": ["markup.changed"], "settings": { "foreground": "#dbbc7f" } }
+  ]
+}

--- a/dots/.bb/theme/neverforest/neverforest-light.json
+++ b/dots/.bb/theme/neverforest/neverforest-light.json
@@ -1,0 +1,36 @@
+{
+  "name": "Neverforest Light",
+  "type": "light",
+  "colors": {
+    "editor.background": "#f6f3ed",
+    "editor.foreground": "#2f363b",
+    "editorLineNumber.foreground": "#97907f",
+    "editorLineNumber.activeForeground": "#45585f",
+    "editorCursor.foreground": "#2f363b",
+    "editor.selectionBackground": "#cde0dc",
+    "editor.inactiveSelectionBackground": "#e4f0e7",
+    "editor.lineHighlightBackground": "#eeeae1",
+    "editorWhitespace.foreground": "#d3c6aa",
+    "editorError.foreground": "#a56163",
+    "editorWarning.foreground": "#9d8a63",
+    "diffEditor.insertedTextBackground": "#e4f0e7",
+    "diffEditor.removedTextBackground": "#f7d3d4"
+  },
+  "tokenColors": [
+    { "scope": ["comment", "punctuation.definition.comment"], "settings": { "foreground": "#77817d", "fontStyle": "italic" } },
+    { "scope": ["string", "constant.numeric", "constant.language", "constant.character"], "settings": { "foreground": "#617f6c" } },
+    { "scope": ["entity.name.function", "support.function", "meta.function-call", "keyword.control"], "settings": { "foreground": "#617f6c" } },
+    { "scope": ["entity.name.type", "entity.name.class", "support.type", "storage.type"], "settings": { "foreground": "#526f76" } },
+    { "scope": ["variable", "constant.other", "variable.parameter"], "settings": { "foreground": "#2f363b" } },
+    { "scope": ["variable.other.property", "variable.other.member", "entity.other.attribute-name"], "settings": { "foreground": "#627078" } },
+    { "scope": ["keyword", "storage.modifier", "punctuation", "meta.brace"], "settings": { "foreground": "#77817d" } },
+    { "scope": ["keyword.operator", "constant.other.symbol"], "settings": { "foreground": "#515a5b" } },
+    { "scope": ["entity.name.tag", "markup.heading"], "settings": { "foreground": "#617f6c" } },
+    { "scope": ["markup.heading.1"], "settings": { "foreground": "#9a7387", "fontStyle": "bold" } },
+    { "scope": ["markup.heading.2"], "settings": { "foreground": "#8a7042", "fontStyle": "bold" } },
+    { "scope": ["markup.underline.link", "string.other.link"], "settings": { "foreground": "#526f76", "fontStyle": "underline" } },
+    { "scope": ["invalid", "invalid.illegal", "markup.deleted"], "settings": { "foreground": "#a56163" } },
+    { "scope": ["markup.inserted"], "settings": { "foreground": "#617f6c" } },
+    { "scope": ["markup.changed"], "settings": { "foreground": "#8a7042" } }
+  ]
+}

--- a/dots/.bb/theme/neverforest/theme.css
+++ b/dots/.bb/theme/neverforest/theme.css
@@ -1,0 +1,151 @@
+/* Neverforest for BB — adapted from ~/.dotfiles/dots/.config/nvim/lua/rmarganti/colors/palette.lua */
+
+:root, .light {
+  /* A light companion palette derived from Neverforest's warm foregrounds. */
+  --canvas: #f6f3ed;
+  --ink: #2f363b;
+  --primary: #65858e;
+  --primary-foreground: #f6f3ed;
+  --timeline-accent: #65858e;
+  --file-accent: var(--timeline-accent);
+
+  /* Explicit neutral surfaces prevent warm text from tinting app chrome. */
+  --background: #f6f3ed;
+  --foreground: #2f363b;
+  --card: #f6f3ed;
+  --card-foreground: #2f363b;
+  --popover: #f6f3ed;
+  --popover-foreground: #2f363b;
+  --secondary: #ebe7de;
+  --secondary-foreground: #2f363b;
+  --accent: #ebe7de;
+  --accent-foreground: #2f363b;
+  --muted: #e4dfd4;
+  --border: #d8d2c5;
+  --border-hairline: #d3cdbf;
+  --border-seam: #e1dcd2;
+  --border-seam-vertical: #e1dcd2;
+  --input: #b8b1a3;
+  --surface-recessed: rgb(47 54 59 / 6%);
+  --surface-recessed-solid: #eae7df;
+  --surface-raised: rgb(47 54 59 / 4%);
+  --surface-raised-solid: #efebe4;
+  --surface-scrim: rgb(246 243 237 / 92%);
+  --state-hover: rgb(47 54 59 / 6%);
+  --state-active: rgb(47 54 59 / 12%);
+  --sidebar: #eeeae1;
+  --sidebar-foreground: #2f363b;
+  --sidebar-accent: #dfdad0;
+  --sidebar-accent-foreground: #2f363b;
+  --sidebar-border: #d8d2c5;
+  --sidebar-ring: #65858e;
+  --ring: #65858e;
+  --surface-selected: #dbe5e5;
+  --surface-selected-border: #8eaaaf;
+
+  --muted-foreground: color-mix(in oklch, var(--ink) 70%, var(--canvas));
+  --subtle-foreground: color-mix(in oklch, var(--ink) 58%, var(--canvas));
+  --readback-foreground: color-mix(in oklch, var(--ink) 64%, var(--canvas));
+
+  --destructive: #a56163;
+  --destructive-foreground: #f6f3ed;
+  --destructive-text: #8f4c4e;
+  --warning: #9d8a63;
+  --warning-text: #725f38;
+  --attention: #9d8a63;
+  --success: #617f6c;
+  --diff-added: #617f6c;
+  --diff-removed: #a56163;
+  --pr-merged: #9a7387;
+
+  --ansi-0: #2f363b;
+  --ansi-1: #a56163;
+  --ansi-2: #617f6c;
+  --ansi-3: #9d8a63;
+  --ansi-4: #65858e;
+  --ansi-5: #9a7387;
+  --ansi-6: #7f9492;
+  --ansi-7: #d3c6aa;
+  --ansi-8: #627078;
+  --ansi-9: #e67e80;
+  --ansi-10: #779482;
+  --ansi-11: #dbbc7f;
+  --ansi-12: #87b5c1;
+  --ansi-13: #d699b6;
+  --ansi-14: #aeccc6;
+  --ansi-15: #f6f3ed;
+
+  --ansi-bg-fg-0: #f6f3ed;
+  --ansi-bg-fg-1: #f6f3ed;
+  --ansi-bg-fg-2: #f6f3ed;
+  --ansi-bg-fg-3: #0d1011;
+  --ansi-bg-fg-4: #f6f3ed;
+  --ansi-bg-fg-5: #f6f3ed;
+  --ansi-bg-fg-6: #0d1011;
+  --ansi-bg-fg-7: #0d1011;
+  --ansi-bg-fg-8: #f6f3ed;
+  --ansi-bg-fg-9: #0d1011;
+  --ansi-bg-fg-10: #0d1011;
+  --ansi-bg-fg-11: #0d1011;
+  --ansi-bg-fg-12: #0d1011;
+  --ansi-bg-fg-13: #0d1011;
+  --ansi-bg-fg-14: #0d1011;
+  --ansi-bg-fg-15: #0d1011;
+}
+
+.dark {
+  --canvas: #1d2226;
+  --ink: #d3c6aa;
+  --primary: #87b5c1;
+  --primary-foreground: #181c1e;
+  --timeline-accent: #87b5c1;
+  --file-accent: var(--timeline-accent);
+
+  /* Map every major BB surface onto Neverforest's neutral background ramp. */
+  --background: #1d2226;
+  --foreground: #d3c6aa;
+  --card: #1d2226;
+  --card-foreground: #d3c6aa;
+  --popover: #23292e;
+  --popover-foreground: #d3c6aa;
+  --secondary: #23292e;
+  --secondary-foreground: #d3c6aa;
+  --accent: #23292e;
+  --accent-foreground: #d3c6aa;
+  --muted: #2a3137;
+  --muted-foreground: #9da9a0;
+  --subtle-foreground: #77817d;
+  --readback-foreground: #9da9a0;
+  --border: #30383f;
+  --border-hairline: #30383f;
+  --border-seam: #2a3137;
+  --border-seam-vertical: #2a3137;
+  --input: #515a5b;
+  --surface-recessed: #181c1e;
+  --surface-recessed-solid: #181c1e;
+  --surface-raised: #23292e;
+  --surface-raised-solid: #23292e;
+  --surface-scrim: rgb(29 34 38 / 92%);
+  --state-hover: rgb(211 198 170 / 6%);
+  --state-active: rgb(211 198 170 / 12%);
+  --sidebar: #181c1e;
+  --sidebar-foreground: #d3c6aa;
+  --sidebar-accent: #23292e;
+  --sidebar-accent-foreground: #d3c6aa;
+  --sidebar-border: #30383f;
+  --sidebar-ring: #87b5c1;
+  --ring: #87b5c1;
+  --surface-selected: #26363a;
+  --surface-selected-border: #45585f;
+
+  --destructive: #e67e80;
+  --destructive-foreground: #181c1e;
+  --destructive-text: #eea9aa;
+  --warning: #dbbc7f;
+  --warning-text: #e6d1a7;
+  --attention: #dbbc7f;
+  --success: #a2ccae;
+  --diff-added: #a2ccae;
+  --diff-removed: #e67e80;
+  --pr-merged: #d699b6;
+}

--- a/dots/.bb/theme/neverforest/theme.json
+++ b/dots/.bb/theme/neverforest/theme.json
@@ -1,0 +1,6 @@
+{
+  "codeTheme": {
+    "dark": "neverforest-dark.json",
+    "light": "neverforest-light.json"
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -53,6 +53,10 @@ dotfiles.default_mode = "symlink"
 "~/.agents" = {}
 "~/.pi" = {}
 
+# Link only portable BB configuration. Never link ~/.bb itself: it also
+# contains credentials, databases, logs, runtime files, and thread data.
+"~/.bb/theme" = {}
+
 "~/.config/bat" = {}
 "~/.config/btop/themes" = {}
 "~/.config/codebook" = {}


### PR DESCRIPTION
## Summary

- add a custom BB theme based on the Neverforest Neovim palette
- include matching dark and light code themes
- manage portable BB theme configuration through mise dotfile symlinks
- ignore BB runtime state, credentials, databases, logs, and sessions

## Verification

- activated the theme with `bb theme set neverforest`
- verified BB resolves both custom code themes
- verified `~/.bb/theme` links to `~/.dotfiles/dots/.bb/theme`